### PR TITLE
Add claude-code-tools, test-tools, and code-review-tools plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,6 +14,21 @@
       "name": "security-tools",
       "source": "./plugins/security-tools",
       "description": "Harden GitHub Actions workflows against supply-chain and injection attacks."
+    },
+    {
+      "name": "claude-code-tools",
+      "source": "./plugins/claude-code-tools",
+      "description": "Meta-tools for running Claude Code well: audit your permission allowlist, fix local toolchain gaps, and analyze usage costs."
+    },
+    {
+      "name": "test-tools",
+      "source": "./plugins/test-tools",
+      "description": "Investigate and fix flaky tests across frameworks and CI systems."
+    },
+    {
+      "name": "code-review-tools",
+      "source": "./plugins/code-review-tools",
+      "description": "Strict structural and architectural code review that hunts for dramatic simplifications."
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.pytest_cache/
+.venv/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Add the marketplace, then install the plugin you want:
 
 - **[skill-tools](./plugins/skill-tools/)** — Tools for authoring and reviewing Claude Code skills. Includes the `skill-review` skill, which reviews skills against a closed 7-category quality rubric (Structural Discipline, Integrity, Test Coverage, Security, Content Quality, Convention, Cost) with structured JSON output and a determinism contract.
 - **[security-tools](./plugins/security-tools/)** — Harden GitHub Actions workflows against supply-chain and injection attacks. Includes the `secure-github-actions` skill (a 14-rule review checklist plus audit commands) and a hook that auto-loads it when you edit a workflow file.
+- **[claude-code-tools](./plugins/claude-code-tools/)** — Meta-tools for running Claude Code well. `permissions-analyzer` vets your permission allowlist against a GREEN/YELLOW/RED safety model; `tool-misses` finds and fixes missing CLI tools / BSD-GNU incompatibilities; `cc-cost-analysis` is a framework for analyzing Claude Code usage costs from OpenTelemetry data.
+- **[test-tools](./plugins/test-tools/)** — Investigate and fix flaky tests. The `fix-flaky-tests` skill detects your framework and CI provider, classifies the flake, and enforces green-CI-as-the-only-verification discipline across RSpec, Jest, pytest, Go test, and more.
+- **[code-review-tools](./plugins/code-review-tools/)** — The `thermo-nuclear-code-review` skill runs an extremely strict structural and architectural review, hunting for "code judo" simplifications rather than correctness bugs or style nits.
 
 ## License
 

--- a/plugins/claude-code-tools/.claude-plugin/plugin.json
+++ b/plugins/claude-code-tools/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "claude-code-tools",
+  "version": "0.1.0",
+  "description": "Meta-tools for running Claude Code well: audit your permission allowlist, fix local toolchain gaps, and analyze usage costs.",
+  "author": {
+    "name": "Fin 2x"
+  },
+  "keywords": [
+    "claude-code",
+    "permissions",
+    "cost",
+    "telemetry",
+    "tooling"
+  ],
+  "license": "MIT"
+}

--- a/plugins/claude-code-tools/CHANGELOG.md
+++ b/plugins/claude-code-tools/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to the `claude-code-tools` plugin are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-07-09
+
+### Added
+
+- Initial release of the `claude-code-tools` plugin.
+- `permissions-analyzer` skill — vets a Claude Code permission allowlist against a GREEN/YELLOW/RED safety model and merges the safe entries into `~/.claude/settings.json`.
+- `tool-misses` skill — scans recent sessions for `command not found` and BSD/GNU incompatibilities, installs missing tools via Homebrew, and records availability in CLAUDE.md.
+- `cc-cost-analysis` skill — a framework and query shapes for analyzing Claude Code usage costs from OpenTelemetry data.
+- Hooks: proactive nudges toward `permissions-analyzer` (after repeated permission prompts) and `tool-misses` (on a detected toolchain failure), both opt-out.

--- a/plugins/claude-code-tools/LICENSE
+++ b/plugins/claude-code-tools/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Intercom
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/claude-code-tools/README.md
+++ b/plugins/claude-code-tools/README.md
@@ -1,0 +1,31 @@
+# claude-code-tools
+
+Meta-tools for running Claude Code well: audit your permission allowlist, fix local toolchain gaps, and analyze usage costs.
+
+Part of the [`fin-2x`](../../README.md) marketplace.
+
+## Install
+
+```
+/plugin marketplace add intercom/2x-skills
+/plugin install claude-code-tools@fin-2x
+```
+
+## Skills
+
+- **[permissions-analyzer](./skills/permissions-analyzer/)** — Vets a Claude Code permission allowlist against a GREEN/YELLOW/RED safety model and merges the safe entries into `~/.claude/settings.json`. Runs on top of the built-in `/fewer-permission-prompts` scan, adding a RED override that never auto-allows shell interpreters or package-manager executors (`npm`, `uv`, `bundle`, `npx`, …).
+- **[tool-misses](./skills/tool-misses/)** — Scans recent Claude Code sessions for `command not found` errors and BSD/GNU incompatibilities on macOS, fixes them via Homebrew, and records availability in CLAUDE.md.
+- **[cc-cost-analysis](./skills/cc-cost-analysis/)** — A framework, ready-to-use query shapes, and cost-model formulas for analyzing Claude Code usage costs from exported OpenTelemetry data (per-user spend, expensive sessions, context bloat, model/token breakdowns).
+
+## Hooks
+
+`claude-code-tools` installs opt-out nudge hooks (all non-blocking — they only inject a context reminder):
+
+- A `PermissionRequest` counter plus a `PostToolUse` hook that suggests `/permissions-analyzer` after you've been prompted for approval several times in a session.
+- A `PostToolUse` hook that suggests `/tool-misses` when a genuine `command not found` or BSD/GNU incompatibility shows up in command output.
+
+Silence either with `/permissions-analyzer disable` / `/tool-misses off` (re-enable with `enable` / `on`).
+
+## License
+
+MIT

--- a/plugins/claude-code-tools/hooks/count-permission-requests.sh
+++ b/plugins/claude-code-tools/hooks/count-permission-requests.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# count-permission-requests.sh - async PermissionRequest hook
+#
+# Increments a per-session counter each time a permission prompt fires.
+# The counter is read by suggest-permissions-analyzer.sh (a PostToolUse hook)
+# to suggest the /permissions-analyzer skill after enough prompts accumulate.
+
+input=$(cat)
+
+session_id=$(echo "$input" | jq -r '.session_id // "unknown"')
+
+count_file="/tmp/permissions-analyzer-count-${session_id}"
+count=0
+if [ -f "$count_file" ]; then
+    count=$(cat "$count_file" 2>/dev/null || echo "0")
+fi
+count=$((count + 1))
+echo "$count" > "$count_file"

--- a/plugins/claude-code-tools/hooks/hooks.json
+++ b/plugins/claude-code-tools/hooks/hooks.json
@@ -1,0 +1,21 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/suggest-permissions-analyzer.sh\"" },
+          { "type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/suggest-tool-misses.sh\"" }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "",
+        "hooks": [
+          { "type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/count-permission-requests.sh\"", "async": true }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/claude-code-tools/hooks/suggest-permissions-analyzer.sh
+++ b/plugins/claude-code-tools/hooks/suggest-permissions-analyzer.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# suggest-permissions-analyzer.sh - PostToolUse hook for Bash
+#
+# Checks the permission request counter (written by count-permission-requests.sh)
+# and suggests the /permissions-analyzer skill once per session after 5+ prompts.
+
+input=$(cat)
+
+session_id=$(echo "$input" | jq -r '.session_id // "unknown"')
+
+# Persistent opt-out — user ran `/permissions-analyzer disable`. Presence of the
+# marker silences the nudge in every session until `/permissions-analyzer enable`.
+if [ -f "$HOME/.claude/.disable-permissions-analyzer-suggestions" ]; then
+    exit 0
+fi
+
+# Check if we already suggested this session
+suggested_marker="/tmp/permissions-analyzer-suggested-${session_id}"
+if [ -f "$suggested_marker" ]; then
+    exit 0
+fi
+
+# Check if enough permission requests have accumulated
+count_file="/tmp/permissions-analyzer-count-${session_id}"
+if [ ! -f "$count_file" ]; then
+    exit 0
+fi
+
+count=$(cat "$count_file" 2>/dev/null || echo "0")
+if [ "$count" -lt 5 ]; then
+    exit 0
+fi
+
+touch "$suggested_marker"
+
+cat << 'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "This user has been prompted for permission approval multiple times this session. They may not know they can reduce future prompts: the built-in /fewer-permission-prompts skill scans their session history and adds safe commands to their permissions allowlist, and the /permissions-analyzer skill audits an allowlist against a GREEN/YELLOW/RED safety model — removing anything unsafe (interpreters, package-manager executors) that should never be auto-allowed. Suggest these after the user completes their current task. Do NOT auto-invoke either skill — just mention them naturally, e.g. 'Tip: run /fewer-permission-prompts to auto-allow safe commands, then /permissions-analyzer to audit the allowlist and strip anything unsafe. (Run /permissions-analyzer disable to stop these tips; /permissions-analyzer enable turns them back on.)' Always include the disable hint so the user knows the suggestion is opt-out."
+  }
+}
+EOF

--- a/plugins/claude-code-tools/hooks/suggest-tool-misses.sh
+++ b/plugins/claude-code-tools/hooks/suggest-tool-misses.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# suggest-tool-misses.sh - PostToolUse hook for Bash
+#
+# Detects genuine "command not found" errors and BSD/GNU incompatibilities in
+# Bash tool output, then suggests the /tool-misses skill once per session.
+#
+# Opt-out: create ~/.claude/.disable-tool-misses-hook (or run `/tool-misses off`)
+# to silence this hook for good. Remove it (or run `/tool-misses on`) to re-enable.
+
+input=$(cat)
+
+# --- Opt-out kill switch --------------------------------------------------
+# Presence of the marker silences the hook entirely. Path is overridable for tests.
+opt_out_file="${TOOL_MISSES_OPT_OUT_FILE:-${HOME}/.claude/.disable-tool-misses-hook}"
+if [ -f "$opt_out_file" ]; then
+    exit 0
+fi
+
+# Extract tool response output (may be an object with .stdout/.stderr or a plain string)
+# Concatenate stdout+stderr so we catch errors regardless of which stream they appear in
+tool_output=$(echo "$input" | jq -r '
+  if (.tool_response | type) == "object" then
+    [.tool_response.stdout // "", .tool_response.stderr // ""] | map(select(. != "")) | join("\n")
+  else
+    (.tool_response // "")
+  end
+' 2>/dev/null || echo "")
+
+if [ -z "$tool_output" ]; then
+    exit 0
+fi
+
+# Only look at FAILED commands. A genuine "command not found" / BSD-GNU error
+# comes from a non-zero exit; a successful command that merely prints the phrase
+# (cat-ing a log, grepping a file, or shell-init noise riding on stderr) is not a
+# real miss. This is the primary guard against the file-content false-positive class.
+is_error=$(echo "$input" | jq -r '
+  if (.tool_response | type) == "string" then
+    (.tool_response | test("Exit code [1-9]"))
+  else
+    ((.tool_response.exit_code // 0) != 0)
+  end
+' 2>/dev/null || echo "false")
+
+if [ "$is_error" != "true" ]; then
+    exit 0
+fi
+
+# Drop lines emitted by Claude Code plugin hook scripts — e.g. another plugin's
+# shell-init function leaking
+# "…/.claude/plugins/cache/foo/hooks/download-harness.sh: line 9: init_hook: command not found"
+# onto stderr. Scope the filter to the plugin install path
+# (".claude/plugins/.../hooks/") rather than any "/hooks/" path, so a miss inside
+# the user's OWN repo ("/workspace/app/hooks/setup.sh: line 12: jq: command not
+# found") is left intact: jq is exactly the kind of installable tool this hook
+# should surface. (The exit-code gate above already drops the original
+# successful-command noise; this is belt-and-suspenders for the rare hook error
+# that rides on a genuinely failed command.)
+signal=$(printf '%s\n' "$tool_output" | grep -Ev '\.claude/plugins/.*/hooks/')
+
+if [ -z "$signal" ]; then
+    exit 0
+fi
+
+found_issue=false
+
+# 1) "command not found" — match only a structured shell diagnostic carrying a
+#    valid command name, mirroring detect-tool-misses.py's MISSING_CMD_PATTERNS
+#    plus its is_false_positive_missing() name validation. The patterns are
+#    LINE-ANCHORED: the command name must sit at the start of the line or behind
+#    a colon-delimited shell prefix ("bash: ", "setup.sh: line 12: "), and the
+#    line must END at "command not found". This rejects prose / test output that
+#    merely contains the phrase mid-sentence (e.g. "docs say hammer: command not
+#    found" or "expected command not found: gsed"), which the old unanchored
+#    pattern let through.
+#      bash/sh form: "[<prefix>: ]*<name>: command not found"
+#      zsh form:     "[<prefix>: ]command not found: <name>"
+#    where <prefix> is a shell/script token ("bash", "setup.sh", "line 12", a
+#    full path) and <name> is a valid command name (letters/digits/._- , no
+#    slashes, colons, or spaces — same charset detect-tool-misses.py accepts).
+bash_form='^[[:space:]]*(([a-zA-Z0-9._/-]+|line [0-9]+): )*[a-zA-Z_][a-zA-Z0-9._-]*: command not found[[:space:]]*$'
+zsh_form='^[[:space:]]*([a-zA-Z0-9._/-]+:?[0-9]*: )?command not found: [a-zA-Z_][a-zA-Z0-9._-]*[[:space:]]*$'
+if printf '%s\n' "$signal" | grep -Eq "$bash_form"; then
+    found_issue=true
+elif printf '%s\n' "$signal" | grep -Eq "$zsh_form"; then
+    found_issue=true
+fi
+
+# 2) BSD/GNU incompatibility patterns (e.g. `grep -P`, `sed -i`, `find -printf`)
+if [ "$found_issue" = false ]; then
+    for pattern in \
+        "invalid option -- P" \
+        "invalid option -- 'P'" \
+        "invalid command code" \
+        "extra characters at the end of .* command" \
+        "unknown primary" \
+        "illegal option" \
+        "invalid option -- V" \
+        "unrecognized option" \
+        "function .* is not defined" \
+        "Option --.*is not supported" \
+        "illegal line count" \
+        "illegal offset"; do
+        if printf '%s\n' "$signal" | grep -Eqi "$pattern"; then
+            found_issue=true
+            break
+        fi
+    done
+fi
+
+if [ "$found_issue" = false ]; then
+    exit 0
+fi
+
+# Only suggest once per session
+session_id=$(echo "$input" | jq -r '.session_id // "unknown"')
+marker="/tmp/tool-misses-suggested-${session_id}"
+
+if [ -f "$marker" ]; then
+    exit 0
+fi
+
+touch "$marker"
+
+cat << 'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "A genuine 'command not found' or BSD/GNU tool incompatibility was detected in command output. Mention to the user — naturally, in one sentence, and do NOT auto-invoke the skill — that they can run /tool-misses to scan recent sessions and install missing CLI tools via Homebrew, and that they can silence these suggestions with /tool-misses off (re-enable later with /tool-misses on)."
+  }
+}
+EOF

--- a/plugins/claude-code-tools/skills/cc-cost-analysis/SKILL.md
+++ b/plugins/claude-code-tools/skills/cc-cost-analysis/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: cc-cost-analysis
+description: >
+  Analyze Claude Code usage costs from OpenTelemetry data — per-user spend,
+  expensive sessions, context bloat, and model/token cost breakdowns — with a
+  structured framework, ready-to-use query shapes, and cost-model formulas.
+  Triggers on "analyze Claude Code costs", "break down the Claude Code bill",
+  "find expensive sessions", "identify context bloat".
+---
+
+# Claude Code Cost Analysis
+
+A framework and ready-to-use query shapes for analyzing Claude Code usage costs across a team or org.
+
+## Prerequisites: you need Claude Code telemetry
+
+Claude Code can export usage as OpenTelemetry metrics and events (`CLAUDE_CODE_ENABLE_TELEMETRY=1` plus an OTLP endpoint — see the Claude Code monitoring docs). Point that export at an observability backend (Honeycomb, Datadog, an OTLP collector into a warehouse, etc.). This skill analyzes that data.
+
+The example queries in `references/queries.md` are written for **Honeycomb** (environment/dataset names are placeholders — substitute wherever you send telemetry). The **analysis dimensions and cost formulas are backend-agnostic** — the same shapes translate to any store that has per-`api_request` rows with token counts, `cost_usd`, `model`, and `session.id`.
+
+A few attribute names in the examples (`user.email`, `speed`, `skill.name`, `normalized_file_path`) are enrichments that depend on your telemetry pipeline and Claude Code version — verify column names against your own data (`get_dataset_columns` or the equivalent) before relying on them. Numeric fields are sometimes stored as strings; cast with `FLOAT(...)` before aggregating (see the query examples).
+
+## Analysis Dimensions
+
+Each dimension answers a different question. Run whichever are relevant — there is no required order, though broader dimensions provide context for narrower ones.
+
+| Dimension | Question Answered | Query Section |
+|-----------|------------------|---------------|
+| Model mix | Which models account for what cost? | `references/queries.md` Section 1 |
+| Session economics | Where in sessions does cost accumulate? | Section 2 |
+| Token types | Cache writes vs reads vs output share? | Section 3 |
+| Tool result sizes | Which tools bloat the context? | Section 4 |
+| Compaction | Are sessions hitting context limits? | Section 5 |
+| Per-user profiles | Who are the heaviest users and why? | Section 6 |
+| Instructions & skills | How much do CLAUDE.md/rules/skills cost? | Section 7 |
+
+Apply cost formulas from `references/cost-model.md` when computing dollar estimates from token counts.
+
+## Illustrative Findings
+
+These are shape-of-the-problem findings from one large deployment — useful to calibrate expectations, **not** ground truth for your org. Always verify against fresh queries against your own data.
+
+### Cost distribution
+
+| Dimension | Typical finding |
+|-----------|---------|
+| Model dominance | The most capable model tends to dominate cost far out of proportion to its share of calls |
+| Session length | A minority of long sessions (turns 100+) can account for the majority of that model's cost |
+| Token type shares | Cache write ~47%, cache read ~44%, output ~9% of weighted cost |
+| Caching savings | Prompt caching typically cuts the bill ~80% vs fully uncached input |
+| Instruction overhead | CLAUDE.md, rules, and skills are collectively a small fraction (~1%) of total spend |
+
+### Session turn phases
+
+| Phase | Turns | Driver |
+|-------|-------|--------|
+| Cache creation | 0-3 | System prompt + instructions written to cache |
+| Steady state | 4-50 | Caching working well — lowest per-call cost |
+| Context growth | 50-99 | Cache reads climbing as context accumulates |
+| Long-session tail | 100+ | Large accumulated context re-read every turn |
+
+### Tool result sizes (typical ranges)
+
+| Category | Avg/call | Examples |
+|----------|---------|---------|
+| Screenshots | 100-500 KB | browser/screenshot tools |
+| Search results | 10-30 KB | search MCP tools |
+| Database results | 5-10 KB | SQL / log query tools |
+| File reads | 3-7 KB | Read tool (very high volume) |
+
+### Context window behavior
+
+- A small fraction of sessions trigger auto compaction.
+- The most expensive sessions rarely compact — they grow to a large context and stay just below the window limit.
+- Sessions on smaller context windows compact more often and cost far less per call than sessions on the largest window with equivalent workloads.
+
+## Key Analysis Patterns
+
+### Matched session comparison
+
+The most compelling way to demonstrate context-size impact on cost is finding two sessions with similar API-call counts but different context behaviors — one with high average cache_read (bloated, likely on the largest window) and one low (lean, compacting or on a smaller window). The per-session query (Section 6a adapted to break down by `session.id`) surfaces these pairs.
+
+### User segmentation by context usage
+
+Classify users by what % of their calls exceed a large cache_read threshold (Section 6a, `calls_over_200k` field):
+- **0% over threshold** — never needs the largest context, would work on a smaller window
+- **1-10%** — rarely needs it, benefits most from proactive compaction
+- **60%+** — genuinely needs the largest context (investigate what tools drive it via Section 6b)
+
+## Important Caveats
+
+**Quality vs cost tradeoff:** Cost optimizations (model downshift, aggressive compaction, smaller context windows) may degrade output quality. Measure quality objectively before changing configuration. Cost savings mean nothing if the tool becomes less useful.
+
+**Caching IS helping:** Prompt caching reduces the bill substantially vs uncached input. The remaining cost is driven by the volume of cached tokens, not by caching being inefficient.
+
+**Instructions are a small share:** CLAUDE.md files, rules, and skills are a small fraction of total spend. The real cost drivers are session length and context accumulation from tool results.
+
+## Generating Reports
+
+Capture findings in markdown reports. See `references/report-templates.md` for standard structures. Name files `{report-type}-{YYYY-MM-DD}.md`.
+
+## Reference Files
+
+- **`references/queries.md`** — Example Honeycomb queries organized by analysis dimension
+- **`references/cost-model.md`** — Token pricing ratios, per-call/per-session cost formulas, caching economics
+- **`references/report-templates.md`** — Standard report structures for each analysis type
+- **`references/column-gotchas.md`** — Data-quality gotchas specific to cost analysis
+
+## Scripts
+
+- **`scripts/compute_percentiles.py`** — Compute p10/p25/p50/p75/p90/p99 from per-user query result sets

--- a/plugins/claude-code-tools/skills/cc-cost-analysis/references/column-gotchas.md
+++ b/plugins/claude-code-tools/skills/cc-cost-analysis/references/column-gotchas.md
@@ -1,0 +1,25 @@
+# Column Gotchas — Cost Analysis Specific
+
+Data-quality gotchas specific to analyzing Claude Code cost telemetry. Field names vary by export pipeline and Claude Code version — verify against your own schema.
+
+## String-stored numerics
+
+Token counts and cost are sometimes exported as strings. Aggregating a string column with `SUM`/`AVG` returns null. Cast first with a calculated field, e.g. `{"name": "cost_f", "expression": "FLOAT($cost_usd)"}`, then aggregate `cost_f`. The example queries use a pre-cast `cost_usd_float` column; adapt to your schema.
+
+## Cost is only meaningful on API-request events
+
+A per-call cost value is only populated on the event that represents an API request (`event.name = "api_request"` in the examples). On hook events, tool events, etc. it is typically 0 or null. Always filter to the API-request event when summing cost.
+
+## event.sequence interpretation
+
+`event.sequence` (where present) is the sequence number across ALL events in a session, not just API requests — sequence 0 might be a hook event, not the first API call. When analyzing the cost curve by turn number, filter to the API-request event and `event.sequence exists` first.
+
+The "OTHER" bucket in `event.sequence` queries (sequence beyond the limit) contains the long-tail turns that typically dominate cost.
+
+## Skill-name fields
+
+Depending on your telemetry, skill invocations may appear under more than one field — one that captures only explicit `Skill` tool calls, and a broader one that also captures `/slash` commands and auto-injected skills. Prefer the broadest field for skill cost analysis, and note that skills can appear under both bare names (`create-pr`) and prefixed names (`some-plugin:create-pr`) — consolidate when aggregating.
+
+## Model identifiers
+
+Model IDs include version dates and change with new releases. Verify current identifiers with a `GROUP BY model` query before hardcoding them in filters.

--- a/plugins/claude-code-tools/skills/cc-cost-analysis/references/cost-model.md
+++ b/plugins/claude-code-tools/skills/cc-cost-analysis/references/cost-model.md
@@ -1,0 +1,96 @@
+# Cost Model Reference
+
+Exact per-token prices change over time and by model. Use the **price ratios** below to compute cost shares from token-count data — the ratios between token types are stable even when absolute prices shift. Check current per-token prices in the Claude pricing docs before converting to dollars.
+
+## Token Pricing Ratios (per model)
+
+For a given model, the four token types price roughly in this proportion:
+
+| Token Type | Price Ratio | Relative to Input |
+|------------|-------------|-------------------|
+| Input (uncached) | 1x | baseline |
+| Cache write | 1.25x | 25% premium |
+| Cache read | 0.10x | **90% discount** |
+| Output | 5x | 5x input |
+
+The absolute price scales by model tier: a mid-tier model is typically several times cheaper per token than the top-tier model, and a small/fast model an order of magnitude cheaper again. The *ratios above hold within each model.*
+
+## Computing Cost Shares from Token Volumes
+
+Given per-model token volumes (from query 1a), compute the **weighted cost contribution** of each token type:
+
+```
+weighted_cache_read   = total_cache_read_tokens     × 0.10
+weighted_cache_write  = total_cache_creation_tokens × 1.25
+weighted_input        = total_input_tokens          × 1.00
+weighted_output       = total_output_tokens         × 5.00
+
+total_weighted = sum of above
+
+cache_read_share  = weighted_cache_read  / total_weighted
+cache_write_share = weighted_cache_write / total_weighted
+output_share      = weighted_output      / total_weighted
+```
+
+Apply these shares to the actual total cost to get dollar amounts per token type.
+
+### Illustrative share breakdown
+
+From one large deployment — verify against your own data:
+
+| Token Type | Share of weighted cost |
+|------------|-------|
+| Cache write | ~47% |
+| Cache read | ~44% |
+| Output | ~9% |
+| Input (uncached) | <1% |
+
+## Caching Savings Estimate
+
+To estimate what the bill WOULD be without caching:
+
+```
+without_caching = total_cache_read_tokens × 1.0 (full input price)
+with_caching    = total_cache_read_tokens × 0.1 (cache read price)
+savings         = without_caching - with_caching
+
+# Cache writes cost 25% more than uncached input:
+write_premium = total_cache_creation_tokens × 0.25
+
+net_savings = savings - write_premium
+```
+
+Because cache reads typically dominate token volume by an order of magnitude over cache writes, net savings tend to land around **80% of what the bill would be without caching**.
+
+## Per-Call and Per-Session Cost Formulas
+
+Substitute your model's current `$cache_write_price` / `$cache_read_price` (per token) into these. The example dollar figures use a top-tier-model price point purely to illustrate the shape — recompute with live prices.
+
+### Instructions (CLAUDE.md, rules) — loaded at session start
+
+```
+per_session_cost = tokens × ($cache_write_price + (avg_turns - 1) × $cache_read_price)
+```
+
+### Skills — loaded mid-session
+
+```
+per_invocation_cost = tokens × ($cache_write_price + remaining_turns × $cache_read_price)
+```
+
+### Tool results — injected at point of call
+
+```
+context_cost = (result_bytes / 4) × ($cache_write_price + remaining_turns × $cache_read_price)
+```
+
+(The `/ 4` approximates ~4 bytes per token for markdown/text.)
+
+## Key Ratios for Quick Estimates
+
+| Metric | Top-tier | Mid-tier | Small/fast |
+|--------|------|--------|-------|
+| Relative $/call | ~2x mid | 1x | ~1/4 mid |
+| Tokens per byte (markdown) | ~0.25 | ~0.25 | ~0.25 |
+
+The single most useful quick estimate: a large accumulated context re-read every turn is what makes long sessions expensive — cost per call climbs with cache-read volume, not with the work being done that turn.

--- a/plugins/claude-code-tools/skills/cc-cost-analysis/references/queries.md
+++ b/plugins/claude-code-tools/skills/cc-cost-analysis/references/queries.md
@@ -1,0 +1,511 @@
+# Cost Analysis Honeycomb Queries
+
+Example query shapes for analyzing Claude Code OpenTelemetry data in Honeycomb. The `environment_slug` / `dataset_slug` values below (`claude-code` / `claude-code-telemetry`) are **placeholders** — substitute the environment and dataset where you export Claude Code telemetry.
+
+A few field names depend on your pipeline and Claude Code version — verify against your own schema first:
+- `cost_usd_float` — a numeric cost column. Claude Code's raw `cost_usd` is sometimes stored as a string; this assumes a pre-cast float column. If yours is a string, declare a calculated field `FLOAT($cost_usd)` and use that instead.
+- `user.email`, `speed`, `skill.name`, `normalized_file_path` — enrichment attributes that may or may not be present in your export.
+
+Default time range: `14d`. Adjust as needed.
+
+---
+
+## Section 1: Model Cost Breakdown
+
+### 1a. Cost, calls, and tokens by model
+
+```json
+{
+  "environment_slug": "claude-code",
+  "dataset_slug": "claude-code-telemetry",
+  "query_spec": {
+    "time_range": "14d",
+    "calculated_fields": [
+      {"name": "input_f", "expression": "FLOAT($input_tokens)"},
+      {"name": "output_f", "expression": "FLOAT($output_tokens)"},
+      {"name": "cache_r_f", "expression": "FLOAT($cache_read_tokens)"},
+      {"name": "cache_c_f", "expression": "FLOAT($cache_creation_tokens)"}
+    ],
+    "calculations": [
+      {"op": "COUNT", "name": "api_calls"},
+      {"op": "SUM", "column": "cost_usd_float", "name": "total_cost"},
+      {"op": "SUM", "column": "input_f", "name": "total_input"},
+      {"op": "SUM", "column": "output_f", "name": "total_output"},
+      {"op": "SUM", "column": "cache_r_f", "name": "total_cache_read"},
+      {"op": "SUM", "column": "cache_c_f", "name": "total_cache_creation"},
+      {"op": "AVG", "column": "cost_usd_float", "name": "avg_cost_per_call"}
+    ],
+    "breakdowns": ["model"],
+    "filters": [
+      {"column": "event.name", "op": "=", "value": "api_request"}
+    ],
+    "orders": [{"op": "SUM", "column": "cost_usd_float", "order": "descending"}],
+    "limit": 20
+  }
+}
+```
+
+### 1b. Cost by speed mode (normal vs fast)
+
+```json
+{
+  "environment_slug": "claude-code",
+  "dataset_slug": "claude-code-telemetry",
+  "query_spec": {
+    "time_range": "14d",
+    "calculations": [
+      {"op": "COUNT", "name": "api_calls"},
+      {"op": "SUM", "column": "cost_usd_float", "name": "total_cost"},
+      {"op": "COUNT_DISTINCT", "column": "session.id", "name": "sessions"},
+      {"op": "AVG", "column": "cost_usd_float", "name": "avg_cost"}
+    ],
+    "breakdowns": ["speed"],
+    "filters": [
+      {"column": "event.name", "op": "=", "value": "api_request"}
+    ],
+    "orders": [{"op": "SUM", "column": "cost_usd_float", "order": "descending"}]
+  }
+}
+```
+
+---
+
+## Section 2: Session Turn Economics
+
+### 2a. Cost curve by event.sequence (Opus only)
+
+Shows how cost evolves as sessions progress through turns. Filter to the dominant model.
+
+```json
+{
+  "environment_slug": "claude-code",
+  "dataset_slug": "claude-code-telemetry",
+  "query_spec": {
+    "time_range": "14d",
+    "calculated_fields": [
+      {"name": "cache_r_f", "expression": "FLOAT($cache_read_tokens)"},
+      {"name": "cache_c_f", "expression": "FLOAT($cache_creation_tokens)"},
+      {"name": "output_f", "expression": "FLOAT($output_tokens)"}
+    ],
+    "calculations": [
+      {"op": "COUNT", "name": "api_calls"},
+      {"op": "SUM", "column": "cost_usd_float", "name": "total_cost"},
+      {"op": "COUNT_DISTINCT", "column": "session.id", "name": "sessions"},
+      {"op": "AVG", "column": "cache_r_f", "name": "avg_cache_read"},
+      {"op": "AVG", "column": "cache_c_f", "name": "avg_cache_write"},
+      {"op": "AVG", "column": "output_f", "name": "avg_output"},
+      {"op": "AVG", "column": "cost_usd_float", "name": "avg_cost"}
+    ],
+    "breakdowns": ["event.sequence"],
+    "filters": [
+      {"column": "event.name", "op": "=", "value": "api_request"},
+      {"column": "event.sequence", "op": "exists"},
+      {"column": "model", "op": "=", "value": "claude-opus-4-6"}
+    ],
+    "orders": [{"column": "event.sequence", "order": "ascending"}],
+    "limit": 100
+  },
+  "results_limit": 100
+}
+```
+
+### 2b. Cost from turns 100+ by model
+
+Quantifies how much of the bill comes from long-running sessions.
+
+```json
+{
+  "environment_slug": "claude-code",
+  "dataset_slug": "claude-code-telemetry",
+  "query_spec": {
+    "time_range": "14d",
+    "calculations": [
+      {"op": "COUNT", "name": "api_calls"},
+      {"op": "SUM", "column": "cost_usd_float", "name": "total_cost"},
+      {"op": "COUNT_DISTINCT", "column": "session.id", "name": "sessions"}
+    ],
+    "breakdowns": ["model"],
+    "filters": [
+      {"column": "event.name", "op": "=", "value": "api_request"},
+      {"column": "event.sequence", "op": ">=", "value": 100}
+    ],
+    "orders": [{"op": "SUM", "column": "cost_usd_float", "order": "descending"}]
+  }
+}
+```
+
+---
+
+## Section 3: Token Type Analysis
+
+### 3a. Context size distribution by model
+
+```json
+{
+  "environment_slug": "claude-code",
+  "dataset_slug": "claude-code-telemetry",
+  "query_spec": {
+    "time_range": "14d",
+    "calculated_fields": [
+      {"name": "cache_r_f", "expression": "FLOAT($cache_read_tokens)"},
+      {"name": "cache_c_f", "expression": "FLOAT($cache_creation_tokens)"},
+      {"name": "all_input_f", "expression": "FLOAT($cache_read_tokens) + FLOAT($cache_creation_tokens) + FLOAT($input_tokens)"}
+    ],
+    "calculations": [
+      {"op": "COUNT", "name": "api_calls"},
+      {"op": "AVG", "column": "all_input_f", "name": "avg_total_context"},
+      {"op": "P50", "column": "all_input_f", "name": "p50_context"},
+      {"op": "P90", "column": "all_input_f", "name": "p90_context"},
+      {"op": "P99", "column": "all_input_f", "name": "p99_context"},
+      {"op": "AVG", "column": "cost_usd_float", "name": "avg_cost"}
+    ],
+    "breakdowns": ["model"],
+    "filters": [
+      {"column": "event.name", "op": "=", "value": "api_request"},
+      {"column": "model", "op": "in", "value": ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"]}
+    ],
+    "orders": [{"op": "COUNT", "order": "descending"}]
+  }
+}
+```
+
+### 3b. Per-call cost percentiles
+
+```json
+{
+  "environment_slug": "claude-code",
+  "dataset_slug": "claude-code-telemetry",
+  "query_spec": {
+    "time_range": "14d",
+    "calculations": [
+      {"op": "COUNT", "name": "api_calls"},
+      {"op": "P50", "column": "cost_usd_float", "name": "p50_cost"},
+      {"op": "P90", "column": "cost_usd_float", "name": "p90_cost"},
+      {"op": "P99", "column": "cost_usd_float", "name": "p99_cost"},
+      {"op": "AVG", "column": "cost_usd_float", "name": "avg_cost"},
+      {"op": "SUM", "column": "cost_usd_float", "name": "total_cost"}
+    ],
+    "filters": [
+      {"column": "event.name", "op": "=", "value": "api_request"}
+    ]
+  }
+}
+```
+
+---
+
+## Section 4: Tool Result Size Analysis
+
+### 4a. All tools by total bytes injected
+
+```json
+{
+  "environment_slug": "claude-code",
+  "dataset_slug": "claude-code-telemetry",
+  "query_spec": {
+    "time_range": "14d",
+    "calculated_fields": [
+      {"name": "result_size_f", "expression": "FLOAT($tool_result_size_bytes)"}
+    ],
+    "calculations": [
+      {"op": "SUM", "column": "result_size_f", "name": "total_bytes"},
+      {"op": "AVG", "column": "result_size_f", "name": "avg_bytes"},
+      {"op": "P50", "column": "result_size_f", "name": "p50_bytes"},
+      {"op": "P90", "column": "result_size_f", "name": "p90_bytes"},
+      {"op": "P99", "column": "result_size_f", "name": "p99_bytes"},
+      {"op": "COUNT", "name": "calls"},
+      {"op": "COUNT_DISTINCT", "column": "user.email", "name": "users"}
+    ],
+    "breakdowns": ["tool_name"],
+    "filters": [
+      {"column": "event.name", "op": "=", "value": "tool_result"},
+      {"column": "tool_result_size_bytes", "op": "exists"}
+    ],
+    "orders": [{"op": "SUM", "column": "result_size_f", "order": "descending"}],
+    "limit": 30
+  }
+}
+```
+
+### 4b. MCP servers by total bytes
+
+```json
+{
+  "environment_slug": "claude-code",
+  "dataset_slug": "claude-code-telemetry",
+  "query_spec": {
+    "time_range": "14d",
+    "calculated_fields": [
+      {"name": "result_size_f", "expression": "FLOAT($tool_result_size_bytes)"}
+    ],
+    "calculations": [
+      {"op": "SUM", "column": "result_size_f", "name": "total_bytes"},
+      {"op": "AVG", "column": "result_size_f", "name": "avg_bytes"},
+      {"op": "P90", "column": "result_size_f", "name": "p90_bytes"},
+      {"op": "P99", "column": "result_size_f", "name": "p99_bytes"},
+      {"op": "COUNT", "name": "calls"},
+      {"op": "COUNT_DISTINCT", "column": "user.email", "name": "users"}
+    ],
+    "breakdowns": ["tool_parameters.mcp_server_name"],
+    "filters": [
+      {"column": "event.name", "op": "=", "value": "tool_result"},
+      {"column": "tool_parameters.mcp_server_name", "op": "exists"},
+      {"column": "tool_result_size_bytes", "op": "exists"}
+    ],
+    "orders": [{"op": "SUM", "column": "result_size_f", "order": "descending"}],
+    "limit": 30
+  }
+}
+```
+
+### 4c. MCP server + tool combos by total bytes
+
+```json
+{
+  "environment_slug": "claude-code",
+  "dataset_slug": "claude-code-telemetry",
+  "query_spec": {
+    "time_range": "14d",
+    "calculated_fields": [
+      {"name": "result_size_f", "expression": "FLOAT($tool_result_size_bytes)"}
+    ],
+    "calculations": [
+      {"op": "SUM", "column": "result_size_f", "name": "total_bytes"},
+      {"op": "AVG", "column": "result_size_f", "name": "avg_bytes"},
+      {"op": "P90", "column": "result_size_f", "name": "p90_bytes"},
+      {"op": "P99", "column": "result_size_f", "name": "p99_bytes"},
+      {"op": "COUNT", "name": "calls"},
+      {"op": "COUNT_DISTINCT", "column": "user.email", "name": "users"}
+    ],
+    "breakdowns": ["tool_parameters.mcp_server_name", "tool_parameters.mcp_tool_name"],
+    "filters": [
+      {"column": "event.name", "op": "=", "value": "tool_result"},
+      {"column": "tool_parameters.mcp_server_name", "op": "exists"},
+      {"column": "tool_result_size_bytes", "op": "exists"}
+    ],
+    "orders": [{"op": "SUM", "column": "result_size_f", "order": "descending"}],
+    "limit": 40
+  },
+  "results_limit": 100
+}
+```
+
+---
+
+## Section 5: Compaction Analysis
+
+### 5a. Compaction events by trigger type
+
+```json
+{
+  "environment_slug": "claude-code",
+  "dataset_slug": "claude-code-telemetry",
+  "query_spec": {
+    "time_range": "14d",
+    "calculations": [
+      {"op": "COUNT", "name": "compactions"},
+      {"op": "COUNT_DISTINCT", "column": "session.id", "name": "sessions"},
+      {"op": "COUNT_DISTINCT", "column": "user.email", "name": "users"}
+    ],
+    "breakdowns": ["trigger"],
+    "filters": [
+      {"column": "event.name", "op": "=", "value": "hook.PreCompact"}
+    ],
+    "orders": [{"op": "COUNT", "order": "descending"}]
+  }
+}
+```
+
+### 5b. Top compacting sessions
+
+```json
+{
+  "environment_slug": "claude-code",
+  "dataset_slug": "claude-code-telemetry",
+  "query_spec": {
+    "time_range": "14d",
+    "calculations": [
+      {"op": "COUNT", "name": "compactions"}
+    ],
+    "breakdowns": ["session.id"],
+    "filters": [
+      {"column": "event.name", "op": "=", "value": "hook.PreCompact"},
+      {"column": "trigger", "op": "=", "value": "auto"}
+    ],
+    "orders": [{"op": "COUNT", "order": "descending"}],
+    "limit": 50
+  },
+  "results_limit": 50
+}
+```
+
+### 5c. Session-level cache read + compaction overlay
+
+To visualize the sawtooth compaction pattern for a specific session, run two queries and view side-by-side in Honeycomb:
+
+**Cache reads (use 600s or 1800s granularity):**
+```json
+{
+  "environment_slug": "claude-code",
+  "dataset_slug": "claude-code-telemetry",
+  "query_spec": {
+    "time_range": "14d",
+    "calculated_fields": [
+      {"name": "cache_r_f", "expression": "FLOAT($cache_read_tokens)"}
+    ],
+    "calculations": [
+      {"op": "AVG", "column": "cache_r_f", "name": "avg_cache_read"},
+      {"op": "MAX", "column": "cache_r_f", "name": "max_cache_read"},
+      {"op": "AVG", "column": "cost_usd_float", "name": "avg_cost"},
+      {"op": "COUNT", "name": "calls"}
+    ],
+    "filters": [
+      {"column": "session.id", "op": "=", "value": "SESSION_ID_HERE"},
+      {"column": "event.name", "op": "=", "value": "api_request"}
+    ],
+    "granularity": 1800
+  }
+}
+```
+
+**Compaction events overlay:**
+```json
+{
+  "environment_slug": "claude-code",
+  "dataset_slug": "claude-code-telemetry",
+  "query_spec": {
+    "time_range": "14d",
+    "calculations": [
+      {"op": "COUNT", "name": "compactions"}
+    ],
+    "filters": [
+      {"column": "session.id", "op": "=", "value": "SESSION_ID_HERE"},
+      {"column": "event.name", "op": "=", "value": "hook.PreCompact"}
+    ],
+    "granularity": 1800
+  }
+}
+```
+
+---
+
+## Section 6: Per-User Deep Dives
+
+### 6a. Per-user Opus profile (cost, context size, % calls >200K)
+
+```json
+{
+  "environment_slug": "claude-code",
+  "dataset_slug": "claude-code-telemetry",
+  "query_spec": {
+    "time_range": "14d",
+    "calculated_fields": [
+      {"name": "cache_r_f", "expression": "FLOAT($cache_read_tokens)"},
+      {"name": "is_large_context", "expression": "IF(GT(FLOAT($cache_read_tokens), 200000), 1, 0)"}
+    ],
+    "calculations": [
+      {"op": "COUNT", "name": "api_calls"},
+      {"op": "SUM", "column": "cost_usd_float", "name": "total_cost"},
+      {"op": "AVG", "column": "cache_r_f", "name": "avg_cache_read"},
+      {"op": "MAX", "column": "cache_r_f", "name": "max_cache_read"},
+      {"op": "P90", "column": "cache_r_f", "name": "p90_cache_read"},
+      {"op": "COUNT_DISTINCT", "column": "session.id", "name": "sessions"},
+      {"op": "SUM", "column": "is_large_context", "name": "calls_over_200k"}
+    ],
+    "breakdowns": ["user.email"],
+    "filters": [
+      {"column": "event.name", "op": "=", "value": "api_request"},
+      {"column": "model", "op": "=", "value": "claude-opus-4-6"}
+    ],
+    "orders": [{"op": "SUM", "column": "cost_usd_float", "order": "descending"}],
+    "limit": 100
+  },
+  "results_limit": 100
+}
+```
+
+### 6b. Tool result breakdown for specific users
+
+Replace the email list with target users.
+
+```json
+{
+  "environment_slug": "claude-code",
+  "dataset_slug": "claude-code-telemetry",
+  "query_spec": {
+    "time_range": "14d",
+    "calculated_fields": [
+      {"name": "result_size_f", "expression": "FLOAT($tool_result_size_bytes)"}
+    ],
+    "calculations": [
+      {"op": "SUM", "column": "result_size_f", "name": "total_bytes"},
+      {"op": "AVG", "column": "result_size_f", "name": "avg_bytes"},
+      {"op": "COUNT", "name": "calls"}
+    ],
+    "breakdowns": ["user.email", "tool_name"],
+    "filters": [
+      {"column": "event.name", "op": "=", "value": "tool_result"},
+      {"column": "user.email", "op": "in", "value": ["user1@example.com", "user2@example.com"]},
+      {"column": "tool_result_size_bytes", "op": "exists"}
+    ],
+    "orders": [{"op": "SUM", "column": "result_size_f", "order": "descending"}],
+    "limit": 40
+  }
+}
+```
+
+---
+
+## Section 7: Instruction & Skill Costs
+
+### 7a. InstructionsLoaded by file (CLAUDE.md, rules)
+
+```json
+{
+  "environment_slug": "claude-code",
+  "dataset_slug": "claude-code-telemetry",
+  "query_spec": {
+    "time_range": "14d",
+    "calculations": [
+      {"op": "COUNT", "name": "loads"},
+      {"op": "COUNT_DISTINCT", "column": "user.email", "name": "users"},
+      {"op": "COUNT_DISTINCT", "column": "session.id", "name": "sessions"}
+    ],
+    "breakdowns": ["normalized_file_path"],
+    "filters": [
+      {"column": "event.name", "op": "=", "value": "hook.InstructionsLoaded"},
+      {"column": "normalized_file_path", "op": "exists"}
+    ],
+    "orders": [{"op": "COUNT", "order": "descending"}],
+    "limit": 100
+  },
+  "results_limit": 500
+}
+```
+
+### 7b. Skill invocations by name
+
+Use `skill.name` (not `tool_parameters.skill_name`) to capture slash commands and auto-injected skills.
+
+```json
+{
+  "environment_slug": "claude-code",
+  "dataset_slug": "claude-code-telemetry",
+  "query_spec": {
+    "time_range": "14d",
+    "calculations": [
+      {"op": "COUNT", "name": "invocations"},
+      {"op": "COUNT_DISTINCT", "column": "user.email", "name": "users"},
+      {"op": "COUNT_DISTINCT", "column": "session.id", "name": "sessions"}
+    ],
+    "breakdowns": ["skill.name"],
+    "filters": [
+      {"column": "skill.name", "op": "exists"},
+      {"column": "event.name", "op": "=", "value": "skill_invocation"}
+    ],
+    "orders": [{"op": "COUNT", "order": "descending"}],
+    "limit": 100
+  },
+  "results_limit": 500
+}
+```

--- a/plugins/claude-code-tools/skills/cc-cost-analysis/references/report-templates.md
+++ b/plugins/claude-code-tools/skills/cc-cost-analysis/references/report-templates.md
@@ -1,0 +1,127 @@
+# Report Templates
+
+Standard markdown report structures for each analysis type. Generate as `.md` files in the working directory.
+
+## Executive Summary Template
+
+```markdown
+# Claude Code Cost Analysis: Executive Summary
+
+**Date:** YYYY-MM-DD
+**Period:** Last 14 days
+**Total spend:** $X
+**Active users:** N across M sessions
+
+## Where the Money Goes
+
+[ASCII chart showing model split, token type split, session length split, context source split]
+
+## Key Findings
+
+1. [Model dominance finding]
+2. [Session length finding]
+3. [Tool results finding]
+4. [Compaction finding]
+5. [Instructions finding]
+
+## Optimization Opportunities, Ranked
+
+| # | Lever | Estimated Savings | % of Bill | Difficulty |
+|---|-------|------------------|----------|------------|
+| 1 | ... | ... | ... | ... |
+
+## Top Specific Actions
+
+| # | Action | Where | Annual Impact |
+|---|--------|-------|--------------|
+
+## Quick Reference Numbers
+
+[Table of key metrics: calls, sessions, avg cost, context sizes, etc.]
+```
+
+## Cost Structure Report Template
+
+```markdown
+# Claude Code Cost Structure Analysis
+
+## How Caching Works (and why it's helping)
+[Cache write vs read mechanics, savings estimate]
+
+## Session Economics: Turn-by-Turn Cost Curve
+[Phase 1-4 breakdown table from event.sequence data]
+
+## The $XK Bill, Decomposed
+[By session length, by model, by token type tables]
+
+## Context Size Distribution
+[P50/P90/P99 by model]
+
+## Ranked Optimization Levers
+[Detailed recommendations with savings estimates]
+```
+
+## Tool Result Size Report Template
+
+```markdown
+# Tool Result Size Analysis
+
+## The Full Context Injection Landscape
+[All tools ranked by total bytes: Read, MCP, Bash, etc.]
+[Estimated context cost by tool type]
+
+## MCP Servers Ranked
+[Server-level table with bytes, calls, avg, P90, P99, users]
+
+## MCP Tools Ranked
+[Tool-level table: top 25 endpoints]
+
+## The Screenshot Problem
+[Combined screenshot stats if applicable]
+
+## High-Volume Workhorses
+[Tools with moderate per-call size but high frequency]
+
+## P99 Outliers
+[Tools with occasional massive results]
+
+## Recommendations by category
+```
+
+## Compaction Analysis Report Template
+
+```markdown
+# Context Window & Compaction Analysis
+
+## Compaction Overview
+[auto vs manual counts, session counts, user counts]
+
+## Most-Compacting Sessions vs Their Cost
+[Table cross-referencing compaction count with session cost]
+[Two patterns: "context bombs" vs "marathon runners"]
+
+## The Counter-Intuitive Finding
+[Compacting sessions are NOT the most expensive]
+[Most expensive sessions rarely compact -- they sit below the limit]
+
+## Case Study: Matched Session Comparison
+[Two sessions with similar calls but different context sizes]
+
+## Per-User Compaction Patterns
+[Top compacting users]
+
+## What This Means for Cost Optimization
+[Proactive compaction proposal with savings estimate]
+```
+
+## Naming Convention
+
+Save reports as: `{report-type}-{YYYY-MM-DD}.md`
+
+Examples:
+- `cost-analysis-executive-summary-2026-04-07.md`
+- `cost-structure-analysis-2026-04-07.md`
+- `tool-result-size-analysis-2026-04-07.md`
+- `context-compaction-analysis-2026-04-07.md`
+- `instruction-cost-analysis-2026-04-07.md`
+```

--- a/plugins/claude-code-tools/skills/cc-cost-analysis/scripts/compute_percentiles.py
+++ b/plugins/claude-code-tools/skills/cc-cost-analysis/scripts/compute_percentiles.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# requires Python 3.10+ (uses list[float] type hints)
+"""Compute percentiles from a list of per-user values.
+
+Usage:
+  echo '{"values": [1.5, 3.2, 10.0, 25.4, 8.1]}' | python3 compute_percentiles.py
+
+  OR with a column name to extract from a Honeycomb result set:
+  echo '<json_rows>' | python3 compute_percentiles.py --column total_cost
+
+The input should be a JSON object with a "values" key containing a list of numbers,
+or a JSON array of objects when --column is specified.
+"""
+
+import json
+import math
+import sys
+import argparse
+
+
+def percentile(sorted_values: list[float], pct: float) -> float:
+    n = len(sorted_values)
+    if n == 0:
+        raise ValueError("No values to compute percentiles from")
+    # Nearest-rank method: ceil(n * pct / 100), clamped to valid range
+    idx = max(0, min(n - 1, math.ceil(n * pct / 100) - 1))
+    return sorted_values[idx]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compute percentiles from Honeycomb query results")
+    parser.add_argument("--column", help="Column name to extract from JSON row objects")
+    parser.add_argument("--exclude-zero", action=argparse.BooleanOptionalAction, default=True,
+                        help="Exclude zero/null values (default: True). Use --no-exclude-zero to include zeros.")
+    args = parser.parse_args()
+
+    data = json.load(sys.stdin)
+
+    def to_float(v) -> float | None:
+        """Convert a value to float, returning None for non-numeric values.
+        Honeycomb returns the string "null" for missing values, not Python None."""
+        if v is None or v == "null":
+            return None
+        try:
+            return float(v)
+        except (ValueError, TypeError):
+            return None
+
+    if args.column:
+        # run_query response wraps rows in a "results" key; also accept bare list
+        rows = data if isinstance(data, list) else data.get("results", data.get("values", []))
+        values = [
+            f for row in rows
+            if (f := to_float(row.get(args.column))) is not None
+            and (not args.exclude_zero or f > 0)
+        ]
+    else:
+        # Accept both "results" (run_query response) and "values" (direct input)
+        raw = data.get("results", data.get("values", []))
+        values = [f for v in raw if (f := to_float(v)) is not None and (not args.exclude_zero or f > 0)]
+
+    if not values:
+        print(json.dumps({"error": "No values after filtering"}))
+        sys.exit(1)
+
+    values.sort()
+    n = len(values)
+
+    result = {
+        "n": n,
+        "min": values[0],
+        "p10": percentile(values, 10),
+        "p25": percentile(values, 25),
+        "p50": percentile(values, 50),
+        "p75": percentile(values, 75),
+        "p90": percentile(values, 90),
+        "p99": percentile(values, 99),
+        "max": values[-1],
+        "mean": sum(values) / n,
+    }
+
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/claude-code-tools/skills/permissions-analyzer/SKILL.md
+++ b/plugins/claude-code-tools/skills/permissions-analyzer/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: permissions-analyzer
+description: |
+  Vet a Claude Code permission allowlist against a GREEN/YELLOW/RED safety model and reduce permission
+  prompts. Runs on top of the built-in /fewer-permission-prompts scan (and permission auto mode):
+  filters proposed auto-allow commands through a GREEN/YELLOW/RED safety model — never auto-allowing
+  interpreters or package-manager executors — before merging the safe ones into ~/.claude/settings.json.
+  Also turns the proactive "reduce your prompts" suggestions off or on (disable/enable).
+disable-model-invocation: true
+metadata:
+  keywords:
+    - settings
+    - approvals
+    - security
+  user-invocable: true
+allowed-tools: Bash Read Write AskUserQuestion
+---
+
+# Permissions Analyzer
+
+The mechanical scan of session history for frequently-approved commands is a job for Claude Code's
+built-in `/fewer-permission-prompts` skill and permission auto mode (https://code.claude.com/docs/en/permissions).
+This skill adds the layer neither provides: an opinionated **safety filter** plus a guarded
+write into the user's global `~/.claude/settings.json`. The built-in scan does not apply the RED
+override below, so it can auto-allow commands this skill would reject — this skill applies the filter.
+
+## Modes
+
+Pick the mode from the argument after `/permissions-analyzer`:
+
+- **`disable`** (or `off`, `stop`, `mute`) — silence the proactive suggestion nudge. Run `touch ~/.claude/.disable-permissions-analyzer-suggestions`, confirm the tips are off for all sessions, and mention `/permissions-analyzer enable` turns them back on. Do not run the vet-and-merge flow.
+- **`enable`** (or `on`) — re-enable the nudge. Check whether `~/.claude/.disable-permissions-analyzer-suggestions` exists, run `rm -f ~/.claude/.disable-permissions-analyzer-suggestions`, then confirm — say the suggestions are back on if the marker existed, or that they were never disabled if it did not. Do not run the vet-and-merge flow.
+- **No argument (default)** — run the vet-and-merge flow below.
+
+The marker only governs the proactive suggestions; the flow is always available by running `/permissions-analyzer` with no argument.
+
+## Vet-and-merge flow
+
+The goal: get safe, high-frequency commands onto the auto-allow list without letting anything that can execute arbitrary code slip through.
+
+1. **Get candidate commands.** Prefer the built-in scan — point the user at `/fewer-permission-prompts`, which mines their session history and proposes an allowlist. Also accept a list the user pastes or the entries already in their `permissions.allow`. For users who want prompts gone entirely rather than command-by-command, mention permission **auto mode** as the broader option. With no candidates supplied and nothing to review, do not fabricate a classified list — route the user to `/fewer-permission-prompts` first, then vet what it returns.
+2. **Audit what the built-in already wrote, and strip RED.** The built-in scan writes to the project `.claude/settings.json` allowlist without applying the RED override. When the user has already run it, read that allowlist (and the user's `~/.claude/settings.json`), identify any RED entries, and — on the same explicit confirmation the write path requires — remove them from the allowlist. Flagging alone is not enough: a RED rule the built-in auto-allowed stays active until it is removed.
+3. **Classify each candidate** into GREEN / YELLOW / RED using `references/safety-tiers.md`. The RED override is the whole point of this skill — see below.
+4. **Present grouped by tier** in a table before asking for confirmation.
+5. **Merge the safe ones** into `~/.claude/settings.json` on explicit confirmation.
+
+## Read `references/safety-tiers.md` first
+
+Classification rules and the permission syntax table live there. Two things matter most:
+
+- **The RED override.** Anything that can execute arbitrary code — directly or via `run`/`exec`/`start` subcommands — is RED, even if the same tool is a "package manager" or "build tool". `npm`, `npx`, `uv`, `bundle`, `pipx`, `bunx`, `deno`, `mise` and bare interpreters (`bash`, `python`, `node`, `ruby`) are never auto-allow candidates.
+- **Read-only is not "looks read-only".** A linter is GREEN only when it cannot mutate files (`eslint` without `--fix`, `rubocop` without `-A`/`-a`).
+
+`references/security-rationale.md` covers the threat model (prompt injection, supply chain, side effects) — cite it when a user pushes back on a RED.
+
+<!--
+Maintainer note: the bullets below are declarative *constraints*, not a runbook — kept
+flat on purpose to avoid procedure smell. Do NOT drop the tier-grouped-table presentation
+or the "preserve other keys" merge rule: both are load-bearing operational facts. The
+get-candidates→classify→confirm→write order is derivable from these constraints; the
+guardrails are not.
+-->
+
+**Constraints:**
+- Present the classified commands grouped by safety tier in a table before asking for confirmation.
+- Dedup against the **target** file — the user's global `~/.claude/settings.json` `permissions.allow`. Skip a command only if it is already allowed there; a command being present in the project `.claude/settings.json` allowlist is not a reason to skip promoting it to the global allowlist.
+- Never write to `~/.claude/settings.json` without explicit user confirmation via `AskUserQuestion`. Show the diff first.
+- When merging accepted patterns into `permissions.allow`, preserve every other key in `settings.json` — surgical merge, never a full-file overwrite.
+- Back up the file before attempting to repair a malformed `settings.json`.
+- Use the Permission Syntax table in `safety-tiers.md` for rule format — don't improvise patterns.
+
+## Resources
+
+- `references/safety-tiers.md` — Classification rules, RED override, permission syntax
+- `references/security-rationale.md` — Threat model and defense layers

--- a/plugins/claude-code-tools/skills/permissions-analyzer/references/safety-tiers.md
+++ b/plugins/claude-code-tools/skills/permissions-analyzer/references/safety-tiers.md
@@ -1,0 +1,104 @@
+# Command Safety Classification
+
+Classify commands by their potential impact, not by name. The same command can be safe or dangerous depending on context and arguments.
+
+**Precedence rule:** If a command can execute arbitrary code — directly or via subcommands like `run`, `exec`, `start` — it is RED, regardless of its other capabilities. Many package managers double as script executors.
+
+## Classification Principles
+
+### GREEN - Safe to Auto-Allow
+
+Commands that meet ALL of these criteria:
+
+- **Read-only**: Does not modify files, state, or external systems
+- **Local scope**: Only accesses the local filesystem
+- **No secrets exposure**: Does not read sensitive files or environment variables
+- **Predictable output**: Results are deterministic and bounded
+
+**Examples of safe activities:**
+- Listing directory contents
+- Searching file contents
+- Checking file metadata
+- Running test suites (sandboxed execution)
+- Running linters and formatters in read-only mode (e.g. `eslint` without `--fix`, `rubocop` without `-A`/`-a`, `prettier --check`). The same tool with a write flag is YELLOW.
+
+### YELLOW - Recommend With Caution
+
+Commands that have legitimate frequent use but carry moderate risk:
+
+- **Modifies local state**: Creates, moves, or edits files
+- **Runs predefined operations**: Build tools, test runners, linters — tools that execute a fixed, known set of operations (NOT arbitrary script execution — see RED)
+- **Version control**: Can modify history or push to remotes
+
+> **Package managers are not YELLOW.** Tools like `npm`, `uv`, `bundle`, `pipx` are sometimes considered "dependency installers" but they all expose subcommands that execute arbitrary user-provided code (`npm exec`, `uv run`, `bundle exec`, `pipx run`) and run lifecycle scripts on install. The RED override below takes precedence — they belong in RED, not here.
+
+**Key consideration:** These commands are often safe in development workflows but can cause issues if misused. Explain the tradeoff and let the user decide.
+
+### RED - Never Auto-Allow
+
+Commands involving any of these risk categories:
+
+**Shell Interpreters**
+- Any command that can execute arbitrary code (bash, sh, zsh, fish, etc.)
+- Script interpreters (python, ruby, node, perl) without specific constraints
+- These bypass all other safety checks since they can run any command
+
+**Package Managers That Execute Code**
+- These tools are primarily package managers but can also execute arbitrary code, making them as dangerous as script interpreters:
+  - `npm` / `npx` — `npm exec`, `npx <pkg>` run arbitrary packages; lifecycle scripts (`preinstall`, `postinstall`) execute on install
+  - `uv` — `uv run` executes arbitrary Python scripts and commands
+  - `bundle` / `bundler` — `bundle exec` runs arbitrary commands in gem context
+  - `pipx` — `pipx run` executes arbitrary Python packages
+  - `bunx` / `bun` — `bunx <pkg>` runs arbitrary packages; `bun run` executes scripts
+  - `deno` — `deno run` executes arbitrary TypeScript/JavaScript
+  - `mise` — `mise exec` / `mise run` executes arbitrary commands
+- The key test: can `<tool> run <script>` or `<tool> exec <command>` execute arbitrary user-provided code? If yes, it belongs here.
+
+**Destructive Operations**
+- Permanent deletion without recovery
+- Overwriting data without backup
+- Resetting state irreversibly
+
+**Secret Exposure**
+- Reading credential files
+- Dumping environment variables
+- Accessing private keys or tokens
+
+**Third-Party System Actions**
+- Cloud infrastructure modifications (AWS, GCP, Azure)
+- Container orchestration changes
+- Remote server access
+- API calls that create, modify, or delete resources
+
+**Privilege Escalation**
+- Running commands as root or another user
+- Modifying file permissions or ownership
+
+**Arbitrary Remote Execution**
+- Downloading and executing scripts
+- Opening network connections for data transfer
+
+---
+
+## Permission Syntax
+
+| Pattern | Meaning |
+|---------|---------|
+| `Bash(git status)` | Exact command only |
+| `Bash(git:*)` | Command with any subcommand/args |
+| `Bash(git add:*)` | Specific subcommand with any args |
+
+---
+
+## Evaluation Questions
+
+When classifying an unfamiliar command, ask:
+
+1. **Is it a shell/script interpreter, or can it execute arbitrary code?** (bash, sh, python, ruby, node, uv, npm, npx, bundle, pipx, bunx, deno, mise) - Always RED
+2. **Does it modify anything?** Files, state, external systems?
+3. **Could it expose secrets?** Reads configs, env vars, credentials?
+4. **Does it affect systems beyond this machine?** Cloud, remote, APIs?
+5. **Is the action reversible?** Can mistakes be undone?
+6. **Does it require elevated privileges?** Sudo, root, other users?
+
+If the answer to any of these is "yes" or "maybe", it should not be auto-allowed.

--- a/plugins/claude-code-tools/skills/permissions-analyzer/references/security-rationale.md
+++ b/plugins/claude-code-tools/skills/permissions-analyzer/references/security-rationale.md
@@ -1,0 +1,67 @@
+# Why Commands Require Approval
+
+Claude Code asks for permission on potentially dangerous commands to protect against unintended consequences.
+
+## Threat Categories
+
+### Data Loss
+
+Operations that permanently destroy data without recovery options. This includes file deletion, overwriting existing content, and resetting version control state. The damage is often irreversible.
+
+### Secret Exposure
+
+Commands that read sensitive files or output credentials. This includes accessing private keys, configuration files with API tokens, environment variables, and shell history. Once exposed in a session, secrets cannot be "unexposed."
+
+### Remote Execution
+
+Downloading and running code from external sources, or opening connections to remote systems. This creates pathways for arbitrary code execution and data exfiltration.
+
+### Third-Party System Actions
+
+Operations on cloud infrastructure, container orchestration, databases, or external APIs. These can affect production systems, incur costs, or impact other users.
+
+### Privilege Escalation
+
+Running commands with elevated privileges or as other users. This bypasses normal permission boundaries and can affect system-wide state.
+
+---
+
+## Defense Model
+
+Even when trusting Claude, approval prompts protect against:
+
+### Prompt Injection Attacks
+
+Malicious content in files, websites, or user input could manipulate Claude into running dangerous commands. Approval prompts break this attack chain by requiring human verification.
+
+### Misunderstanding Intent
+
+Natural language is ambiguous. "Clean up the directory" could mean organizing files or deleting them. Approval ensures the intended action matches what will actually happen.
+
+### Scope Creep
+
+A simple fix might cascade into broader changes. Approval points provide checkpoints to verify scope before each potentially impactful operation.
+
+### Unintended Side Effects
+
+Commands can have non-obvious consequences beyond their primary purpose, such as running scripts during package installation or triggering CI pipelines on push.
+
+---
+
+## The Approval Tradeoff
+
+**The cost:** A few extra keystrokes per session
+
+**The benefit:** Protection against accidental data loss, secret exposure, infrastructure damage, runaway costs, and security breaches.
+
+The small inconvenience of approving commands is worth the protection it provides.
+
+---
+
+## Recommended Approach
+
+1. **Auto-allow read-only operations** - No risk, high frequency
+2. **Consider auto-allowing development tools** - Sandboxed, predictable, frequent use
+3. **Never auto-allow destructive or privileged operations** - Low frequency, high risk
+
+The goal is reducing friction on safe operations while maintaining guardrails on dangerous ones.

--- a/plugins/claude-code-tools/skills/tool-misses/SKILL.md
+++ b/plugins/claude-code-tools/skills/tool-misses/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: tool-misses
+description: >
+  Scan recent Claude Code sessions for "command not found" errors and BSD/GNU
+  incompatibilities on macOS, fix them via Homebrew, and record availability in
+  CLAUDE.md; runs only when the user invokes /tool-misses (scan | on | off | status).
+disable-model-invocation: true
+metadata:
+  keywords:
+    - gsed
+    - ggrep
+    - gnu-sed
+  user-invocable: true
+allowed-tools: Bash Read Edit Write AskUserQuestion
+---
+
+# Tool Misses
+
+Scan recent Claude Code sessions for tool failures — missing commands and BSD/GNU
+incompatibilities — then fix them with Homebrew and record availability in CLAUDE.md.
+
+## Response Style
+
+Skip narration and transitional commentary. Run each step, then present the findings
+or ask the user directly. Do not preface tool calls with sentences like "Now I'll run
+the scanner" or "Let me check whether Homebrew is installed", and do not paraphrase
+script output the user can already see — show the tables and the questions, nothing else.
+
+## Workflow
+
+### Step 0: Handle enable/disable arguments
+
+This skill accepts an optional argument that controls its companion PostToolUse
+hook (`suggest-tool-misses.sh`), which nudges the user toward this skill when a
+tool failure is detected in Bash output. The hook reads a persistent marker file
+at `~/.claude/.disable-tool-misses-hook` and stays silent whenever it exists.
+
+Dispatch on the argument before doing anything else:
+
+- `off`, `disable`, `stop`, `mute`, or `silence` → silence the hook:
+  ```bash
+  touch ~/.claude/.disable-tool-misses-hook
+  ```
+  Confirm suggestions are off until re-enabled with `/tool-misses on`, then STOP
+  (do not run a scan).
+- `on`, `enable`, `start`, or `unmute` → re-enable the hook:
+  ```bash
+  rm -f ~/.claude/.disable-tool-misses-hook
+  ```
+  Confirm suggestions are back on, then STOP (do not run a scan).
+- `status` → report whether the hook is on or off:
+  ```bash
+  test -f ~/.claude/.disable-tool-misses-hook && echo "off" || echo "on"
+  ```
+  Report the result, then STOP.
+- No argument, `scan`, or anything else → proceed to Step 1.
+
+### Step 1: Detect tool misses
+
+Run the scanner script against recent session transcripts:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/tool-misses/scripts/detect-tool-misses.py
+```
+
+This scans `~/.claude/projects/*/*.jsonl` files from the last 14 days. It looks at
+Bash `tool_use` + `tool_result` pairs and matches error output against two pattern sets:
+
+- **Missing tools**: `command not found` errors
+- **Wrong version / incompatibility**: BSD vs GNU errors (e.g., `grep -P` failing,
+  `sed -i` syntax differences, `find -printf` not supported)
+
+Output is JSON with `missing_tools[]`, `wrong_version_tools[]`, and `scan_summary{}`.
+
+If the script finds no misses, report that and stop.
+
+### Step 2: Check current state
+
+For each detected tool, check whether it has already been resolved:
+
+```bash
+command -v <tool>        # Is it installed now?
+command -v g<tool>       # Is the GNU version available?
+brew --prefix 2>/dev/null # Is Homebrew installed?
+```
+
+Categorize each tool as: still missing, now installed but not in CLAUDE.md, or fully resolved.
+
+### Step 3: Look up fixes
+
+Consult `references/tool-database.md` for each detected tool to find:
+- The correct Homebrew formula
+- The g-prefix command name (for GNU tools)
+- Guidance text for CLAUDE.md
+
+For tools not in the database, note them as "unknown — manual resolution needed".
+
+### Step 4: Present report
+
+Show the findings in tables grouped by status:
+
+```
+## Missing Tools (not currently installed)
+| Tool | Error | Homebrew Formula | Occurrences |
+|------|-------|------------------|-------------|
+| filterdiff | command not found | patchutils | 3 |
+
+## BSD/GNU Incompatibilities
+| Tool | Error Pattern | Fix | g-prefix |
+|------|---------------|-----|----------|
+| grep | invalid option -- P | brew install grep | ggrep |
+
+## Already Resolved (installed since the error)
+| Tool | Status |
+|------|--------|
+| jq   | Now installed |
+
+## GNU Tools Available but Not in CLAUDE.md
+| Tool | g-prefix | Formula |
+|------|----------|---------|
+| gsed | gsed     | gnu-sed |
+```
+
+Only show sections that have entries. If everything is resolved, say so and skip to Step 8.
+
+If the scanner output includes `ignored_tools`, mention how many were skipped:
+```
+(3 previously dismissed tools hidden — edit ~/.claude/tool-misses-ignored.json to reset)
+```
+
+### Step 5: Prompt for action — per tool
+
+Present each detected tool individually for the user to decide. For each tool,
+use AskUserQuestion with these options:
+
+- **Install + add to CLAUDE.md** (Recommended) — Install via Homebrew and record in CLAUDE.md
+- **Install only** — Install but don't modify CLAUDE.md
+- **CLAUDE.md only** — Already installed, just add the CLAUDE.md entry
+- **Dismiss permanently** — Not needed; hide from future scans
+
+If a tool has no known Homebrew formula, adjust options to only show "Dismiss permanently"
+and "Skip for now".
+
+**Dismiss behavior:** When the user dismisses a tool, add it to `~/.claude/tool-misses-ignored.json`:
+
+```json
+{
+  "ignored": ["qmd", "init_common"],
+  "notes": {
+    "qmd": "Dismissed 2026-02-08 — short-term experiment",
+    "init_common": "Dismissed 2026-02-08 — shell function, not a tool"
+  }
+}
+```
+
+Read the file first (or start with empty `{"ignored":[], "notes":{}}`) and merge.
+The scanner automatically filters out tools in this list on future runs.
+
+### Step 6: Install tools
+
+For each tool the user approved for installation:
+
+```bash
+brew install <formula>
+```
+
+After each install, verify it worked:
+
+```bash
+command -v <tool> && echo "OK" || echo "FAILED"
+```
+
+If a GNU tool was installed, also verify the g-prefix command:
+
+```bash
+command -v g<tool> && echo "OK" || echo "FAILED"
+```
+
+Report any install failures and continue with the rest.
+
+### Step 7: Update CLAUDE.md
+
+Add a `## Tool Availability (macOS)` section to `~/.claude/CLAUDE.md` (global config,
+since these are system-wide tools). Follow these rules:
+
+- Consult `references/claude-md-templates.md` for entry format
+- Show proposed additions before writing — never write without confirmation
+- Don't duplicate entries that already exist in CLAUDE.md
+- If the section already exists, append new entries to it
+- If the file doesn't exist, create it with just the tool availability section
+
+Read the current file first:
+
+```bash
+cat ~/.claude/CLAUDE.md 2>/dev/null || echo ""
+```
+
+Show the proposed changes as a diff-style preview before applying.
+
+### Step 8: Summarize
+
+Show a final summary:
+
+```
+## Summary
+
+Installed: filterdiff (patchutils), rg (ripgrep)
+CLAUDE.md: Added 3 entries to ~/.claude/CLAUDE.md
+  - GNU grep available as ggrep
+  - GNU sed available as gsed
+  - filterdiff available (patchutils)
+
+Dismissed: qmd, init_common (won't appear in future scans)
+No action needed: jq (already installed and in CLAUDE.md)
+```
+
+## Error Handling
+
+**No session files found:**
+- Check if `~/.claude/projects/` exists
+- Suggest the user has a new install or cleared history
+- Offer to scan a custom path
+
+**Homebrew not installed:**
+- Warn that brew is required for installation
+- Still offer to update CLAUDE.md with manual install instructions
+- Provide the Homebrew install command: `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+
+**Script errors:**
+- If the Python script fails, show the error and suggest running it manually
+- Fall back to a simpler scan if needed
+
+## Additional Resources
+
+- `references/tool-database.md` — Complete error pattern → Homebrew formula mappings
+- `references/claude-md-templates.md` — Templates for CLAUDE.md entries
+- `scripts/detect-tool-misses.py` — Session scanner script

--- a/plugins/claude-code-tools/skills/tool-misses/references/claude-md-templates.md
+++ b/plugins/claude-code-tools/skills/tool-misses/references/claude-md-templates.md
@@ -1,0 +1,109 @@
+# CLAUDE.md Templates
+
+Templates for adding tool availability entries to CLAUDE.md files.
+
+## Section Header
+
+```markdown
+## Tool Availability (macOS)
+```
+
+This section should be placed at the end of the CLAUDE.md file, after any existing
+project-specific guidance.
+
+## Entry Templates
+
+### GNU tool (BSD replacement)
+
+```markdown
+- GNU {tool} is available as `g{tool}` (`brew install {formula}`). Use `g{tool}` instead of `{tool}` when you need {specific_capability}.
+```
+
+**Examples:**
+
+```markdown
+- GNU sed is available as `gsed` (`brew install gnu-sed`). Use `gsed` instead of `sed` for in-place editing (`-i`) and extended regex.
+- GNU grep is available as `ggrep` (`brew install grep`). Use `ggrep -P` for Perl-compatible regex; BSD grep only supports `-E` (extended).
+- GNU find is available as `gfind` (`brew install findutils`). Use `gfind` when you need `-printf` or `-regextype`.
+- GNU xargs is available as `gxargs` (`brew install findutils`). Use `gxargs` when you need `-d` (delimiter) or `-P` (parallel).
+- GNU date is available as `gdate` (`brew install coreutils`). Use `gdate -d` to parse date strings; BSD date uses `-j -f` instead.
+- GNU readlink is available as `greadlink` (`brew install coreutils`). Use `greadlink -f` for canonical paths; BSD readlink doesn't support `-f`.
+- GNU stat is available as `gstat` (`brew install coreutils`). Use `gstat --format` for GNU-style format strings; BSD stat uses `-f`.
+- GNU awk is available as `gawk` (`brew install gawk`). Use `gawk` for GNU-specific functions like `mktime` and `strftime`.
+- GNU tar is available as `gtar` (`brew install gnu-tar`). Use `gtar` for GNU-specific options.
+- GNU sort is available as `gsort` (`brew install coreutils`). Use `gsort -V` for version sorting.
+```
+
+### Missing tool (newly installed)
+
+```markdown
+- `{command}` is available (`brew install {formula}`). {brief_usage_note}.
+```
+
+**Examples:**
+
+```markdown
+- `filterdiff` is available (`brew install patchutils`). Use for extracting specific files from patch output.
+- `rg` (ripgrep) is available (`brew install ripgrep`). Fast regex search across files.
+- `jq` is available (`brew install jq`). Use for JSON processing in shell commands.
+- `delta` is available (`brew install git-delta`). Enhanced diff viewer for git.
+- `fd` is available (`brew install fd`). Fast file finder, alternative to `find`.
+- `bat` is available (`brew install bat`). Cat with syntax highlighting and line numbers.
+- `perl` is available (`brew install perl`). Use for one-liners requiring Perl regex features.
+- `wget` is available (`brew install wget`). Use for HTTP downloads when curl syntax is cumbersome.
+- `tree` is available (`brew install tree`). Use for directory tree visualization.
+- `watch` is available (`brew install watch`). Use for running commands periodically.
+- `shellcheck` is available (`brew install shellcheck`). Shell script linter.
+```
+
+### Python special case
+
+```markdown
+- Use `python3` explicitly — `python` is not available on macOS by default. If both are needed: `brew install python@3.12`.
+```
+
+## Placement Rules
+
+### System-wide tools → `~/.claude/CLAUDE.md`
+
+Tools installed via Homebrew are system-wide, so their availability should be
+recorded in the global CLAUDE.md:
+
+```
+~/.claude/CLAUDE.md
+```
+
+This ensures every Claude Code session knows about available tools, regardless
+of which project directory it's running in.
+
+### Project-specific tools → `./CLAUDE.md`
+
+If a tool is only relevant to a specific project (e.g., a project-specific linter
+or build tool), add it to the project's local CLAUDE.md instead:
+
+```
+./CLAUDE.md           # project root
+./.claude/CLAUDE.md   # project claude config
+```
+
+## Deduplication Rules
+
+Before adding any entry:
+
+1. Read the existing CLAUDE.md file
+2. Check if the tool name is already mentioned (case-insensitive search)
+3. If found, skip that entry — don't duplicate
+4. If the existing entry is outdated (wrong formula, missing g-prefix), update it
+
+## Full Section Example
+
+```markdown
+## Tool Availability (macOS)
+
+- GNU sed is available as `gsed` (`brew install gnu-sed`). Use `gsed` instead of `sed` for in-place editing (`-i`) and extended regex.
+- GNU grep is available as `ggrep` (`brew install grep`). Use `ggrep -P` for Perl-compatible regex; BSD grep only supports `-E` (extended).
+- GNU find is available as `gfind` (`brew install findutils`). Use `gfind` when you need `-printf` or `-regextype`.
+- `filterdiff` is available (`brew install patchutils`). Use for extracting specific files from patch output.
+- `jq` is available (`brew install jq`). Use for JSON processing in shell commands.
+- Use `python3` explicitly — `python` is not available on macOS by default.
+```

--- a/plugins/claude-code-tools/skills/tool-misses/references/tool-database.md
+++ b/plugins/claude-code-tools/skills/tool-misses/references/tool-database.md
@@ -1,0 +1,232 @@
+# Tool Database
+
+Complete reference of error patterns, Homebrew formulae, and fix guidance for
+the `tool-misses` skill.
+
+## Missing Tool → Homebrew Formula Mappings
+
+### Text Processing
+
+| Command | Formula | Description |
+|---------|---------|-------------|
+| `filterdiff` | `patchutils` | Extract diffs from patch files |
+| `combinediff` | `patchutils` | Combine two incremental patches |
+| `lsdiff` | `patchutils` | List files in a patch |
+| `splitdiff` | `patchutils` | Split a patch by file |
+| `interdiff` | `patchutils` | Diff between two patches |
+| `colordiff` | `colordiff` | Colorized diff output |
+| `diff-so-fancy` | `diff-so-fancy` | Better-looking git diffs |
+
+### Search & File Tools
+
+| Command | Formula | Description |
+|---------|---------|-------------|
+| `rg` | `ripgrep` | Fast regex search (replacement for grep -r) |
+| `fd` | `fd` | Fast file finder (replacement for find) |
+| `ag` | `the_silver_searcher` | Code search (The Silver Searcher) |
+| `fzf` | `fzf` | Fuzzy finder |
+| `tree` | `tree` | Directory tree listing |
+
+### JSON / YAML / Data
+
+| Command | Formula | Description |
+|---------|---------|-------------|
+| `jq` | `jq` | JSON processor |
+| `yq` | `yq` | YAML processor |
+| `csvkit` | `csvkit` | CSV toolkit |
+| `xmlstarlet` | `xmlstarlet` | XML toolkit |
+| `htmlq` | `htmlq` | HTML selector (like jq for HTML) |
+
+### Git Tools
+
+| Command | Formula | Description |
+|---------|---------|-------------|
+| `delta` | `git-delta` | Better git diff viewer |
+| `gh` | `gh` | GitHub CLI |
+| `hub` | `hub` | GitHub wrapper for git |
+| `tig` | `tig` | Text-mode interface for git |
+| `git-lfs` | `git-lfs` | Git Large File Storage |
+
+### Programming Languages & Runtimes
+
+| Command | Formula | Notes |
+|---------|---------|-------|
+| `python` | — | **Ignored.** macOS removed `python` in 12.3+. Use `python3`. |
+| `python3` | `python@3.12` | Usually already present via Xcode CLT |
+| `pytest` | — | **Ignored.** Install via `pip3 install pytest`, not Homebrew. |
+| `node` | `node` | Node.js runtime |
+| `ruby` | `ruby` | Ruby runtime |
+| `perl` | `perl` | Perl runtime |
+| `go` | `go` | Go language |
+| `rustc` | `rust` | Rust compiler |
+| `cargo` | `rust` | Rust package manager |
+
+### Build & Dev Tools
+
+| Command | Formula | Description |
+|---------|---------|-------------|
+| `cmake` | `cmake` | Cross-platform build system |
+| `make` | `make` | GNU Make |
+| `pkg-config` | `pkg-config` | Library compile/link flags |
+| `autoconf` | `autoconf` | Autotools configure generator |
+| `automake` | `automake` | Autotools Makefile generator |
+
+### Network Tools
+
+| Command | Formula | Description |
+|---------|---------|-------------|
+| `wget` | `wget` | HTTP/FTP downloader |
+| `curl` | `curl` | URL transfer tool |
+| `httpie` | `httpie` | User-friendly HTTP client |
+| `nmap` | `nmap` | Network scanner |
+| `netcat` / `nc` | `netcat` | TCP/UDP networking utility |
+
+### System Tools
+
+| Command | Formula | Description |
+|---------|---------|-------------|
+| `watch` | `watch` | Run command periodically |
+| `htop` | `htop` | Interactive process viewer |
+| `pstree` | `pstree` | Process tree |
+
+### Shell Utilities
+
+| Command | Formula | Description |
+|---------|---------|-------------|
+| `bat` | `bat` | Cat with syntax highlighting |
+| `eza` | `eza` | Modern ls replacement |
+| `entr` | `entr` | Run command on file changes |
+| `parallel` | `parallel` | GNU Parallel for shell |
+| `pv` | `pv` | Pipe viewer (progress bar) |
+| `rename` | `rename` | Batch file rename |
+| `shellcheck` | `shellcheck` | Shell script linter |
+| `shfmt` | `shfmt` | Shell script formatter |
+| `dos2unix` | `dos2unix` | Line ending converter |
+
+### Compression
+
+| Command | Formula | Description |
+|---------|---------|-------------|
+| `pigz` | `pigz` | Parallel gzip |
+| `pbzip2` | `pbzip2` | Parallel bzip2 |
+| `xz` | `xz` | XZ compression |
+| `zstd` | `zstd` | Zstandard compression |
+
+## BSD vs GNU Incompatibility Patterns
+
+These are errors that occur when Claude uses GNU-style flags with macOS BSD tools.
+
+### sed (gnu-sed → gsed)
+
+| Error Pattern | Regex | Cause |
+|---------------|-------|-------|
+| `sed: 1: "...": invalid command code` | `sed: 1:.*: invalid command code` | GNU sed syntax not recognized by BSD sed |
+| `sed: 1: "...": extra characters at the end of ... command` | `sed: 1:.*: extra characters at the end of .* command` | BSD sed requires different escaping |
+| `sed: -i: ...: No such file or directory` | `sed: -[iI]: .*: No such file or directory` | BSD sed `-i` requires an extension argument (`-i ''`) |
+
+**Fix:** `brew install gnu-sed` → use `gsed` instead of `sed`
+
+### grep (grep → ggrep)
+
+| Error Pattern | Regex | Cause |
+|---------------|-------|-------|
+| `grep: invalid option -- P` | `grep: invalid option -- P` | BSD grep doesn't support Perl-compatible regex (`-P`) |
+
+**Fix:** `brew install grep` → use `ggrep -P` or use `grep -E` for extended regex
+
+### find (findutils → gfind)
+
+| Error Pattern | Regex | Cause |
+|---------------|-------|-------|
+| `find: -printf: unknown primary` | `find: -printf: unknown primary` | BSD find doesn't support `-printf` |
+| `find: -regextype: unknown primary` | `find: -regextype: unknown primary` | BSD find doesn't support `-regextype` |
+
+**Fix:** `brew install findutils` → use `gfind` instead of `find`
+
+### xargs (findutils → gxargs)
+
+| Error Pattern | Regex | Cause |
+|---------------|-------|-------|
+| `xargs: illegal option -- d` | `xargs: illegal option -- d` | BSD xargs doesn't support `-d` (custom delimiter) |
+| `xargs: illegal option -- P` | `xargs: illegal option -- P` | BSD xargs doesn't support `-P` (parallel) |
+
+**Fix:** `brew install findutils` → use `gxargs` instead of `xargs`
+
+### date (coreutils → gdate)
+
+| Error Pattern | Regex | Cause |
+|---------------|-------|-------|
+| `date: illegal option -- d` | `date: illegal option -- d` | BSD date doesn't support `-d` (parse date string) |
+| `date: illegal option -- -` | `date: illegal option -- -` | BSD date doesn't support GNU long options |
+
+**Fix:** `brew install coreutils` → use `gdate` instead of `date`
+
+### readlink (coreutils → greadlink)
+
+| Error Pattern | Regex | Cause |
+|---------------|-------|-------|
+| `readlink: illegal option -- f` | `readlink: illegal option -- f` | BSD readlink doesn't support `-f` (canonicalize) |
+
+**Fix:** `brew install coreutils` → use `greadlink -f` instead of `readlink -f`
+
+### stat (coreutils → gstat)
+
+| Error Pattern | Regex | Cause |
+|---------------|-------|-------|
+| `stat: illegal option -- -` | `stat: illegal option -- -` | BSD stat uses completely different syntax |
+| `stat: unrecognized option` | `stat: unrecognized option` | BSD stat uses `-f` format, not `--format` |
+
+**Fix:** `brew install coreutils` → use `gstat` instead of `stat`
+
+### awk (gawk → gawk)
+
+| Error Pattern | Regex | Cause |
+|---------------|-------|-------|
+| `awk: ... function ... is not defined` | `awk: .*function .* is not defined` | BSD awk lacks some GNU awk functions (e.g., `mktime`, `strftime`) |
+| `awk: ... unknown option` | `awk: .*: unknown option` | BSD awk doesn't support some GNU awk flags |
+
+**Fix:** `brew install gawk` → use `gawk` instead of `awk`
+
+### tar (gnu-tar → gtar)
+
+| Error Pattern | Regex | Cause |
+|---------------|-------|-------|
+| `tar: Option --<name> is not supported` | `tar: Option --\w+ is not supported` | BSD tar missing some GNU tar options |
+
+**Fix:** `brew install gnu-tar` → use `gtar` instead of `tar`
+
+### sort (coreutils → gsort)
+
+| Error Pattern | Regex | Cause |
+|---------------|-------|-------|
+| `sort: invalid option -- V` | `sort: invalid option -- V` | BSD sort doesn't support `-V` (version sort) |
+
+**Fix:** `brew install coreutils` → use `gsort -V` instead of `sort -V`
+
+## Special Cases
+
+### python vs python3
+
+macOS may have `python3` via Xcode Command Line Tools but not `python`. The
+`python` command was removed in macOS 12.3+.
+
+- If `python` is missing but `python3` exists: suggest adding an alias or using `python3` explicitly
+- If both are missing: `brew install python@3.12`
+- CLAUDE.md guidance: "Use `python3` explicitly — `python` is not available on macOS by default."
+
+### Sandbox false positives
+
+Claude Code's sandbox blocks direct use of some commands (like `cat`, `head`, `ls`).
+Errors for these look like "command not found" but the tool IS installed — Claude
+just needs to use the dedicated Read/Glob/Grep tools instead. The scanner filters
+these out automatically.
+
+### Tools with non-obvious formula names
+
+| Command | Formula | Why |
+|---------|---------|-----|
+| `rg` | `ripgrep` | Binary name differs from formula |
+| `ag` | `the_silver_searcher` | Binary name differs from formula |
+| `fd` | `fd` | Same name but easy to confuse |
+| `delta` | `git-delta` | Avoids conflict with another `delta` |
+| `python` | `python@3.12` | Versioned formula |

--- a/plugins/claude-code-tools/skills/tool-misses/scripts/detect-tool-misses.py
+++ b/plugins/claude-code-tools/skills/tool-misses/scripts/detect-tool-misses.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+"""
+Scan recent Claude Code session transcripts for tool misses.
+
+Looks at Bash tool_use + tool_result pairs in JSONL session files and detects:
+- Missing tools ("command not found" errors)
+- BSD/GNU incompatibilities (macOS BSD tools failing with GNU-style flags)
+
+Outputs JSON to stdout with missing_tools[], wrong_version_tools[], scan_summary{}.
+"""
+
+import json
+import os
+import re
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+# --- Configuration ---
+
+SESSIONS_DIR = Path.home() / ".claude" / "projects"
+IGNORE_FILE = Path.home() / ".claude" / "tool-misses-ignored.json"
+DEFAULT_DAYS = 14
+
+# Tools that are sandbox-blocked builtins (false positives for "command not found")
+SANDBOX_BUILTINS = {
+    "head", "cat", "ls", "tail", "sed", "awk", "echo", "find", "grep",
+    "sort", "uniq", "wc", "tr", "cut", "tee", "xargs", "mv", "cp",
+    "rm", "mkdir", "rmdir", "touch", "chmod", "chown", "ln",
+    "printf", "read", "test",
+}
+
+# Commands to ignore — not installable via Homebrew, or the "missing" version is
+# expected on macOS (e.g., `python` doesn't exist, use `python3` instead)
+IGNORE_COMMANDS = {
+    "python",   # macOS removed `python` in 12.3+; `python3` is the correct command
+    "pytest",   # pip package, not a Homebrew formula
+    "pip",      # pip package manager — comes with python3
+}
+
+# --- Missing tool → Homebrew formula mappings ---
+
+TOOL_TO_FORMULA = {
+    # Text processing
+    "filterdiff": "patchutils",
+    "combinediff": "patchutils",
+    "lsdiff": "patchutils",
+    "splitdiff": "patchutils",
+    "interdiff": "patchutils",
+    "colordiff": "colordiff",
+    "diff-so-fancy": "diff-so-fancy",
+    # Search & file tools
+    "rg": "ripgrep",
+    "fd": "fd",
+    "ag": "the_silver_searcher",
+    "fzf": "fzf",
+    "tree": "tree",
+    # JSON / YAML / data
+    "jq": "jq",
+    "yq": "yq",
+    "csvkit": "csvkit",
+    "xmlstarlet": "xmlstarlet",
+    "htmlq": "htmlq",
+    # Git tools
+    "delta": "git-delta",
+    "gh": "gh",
+    "hub": "hub",
+    "tig": "tig",
+    "git-lfs": "git-lfs",
+    # Programming languages & runtimes
+    "python3": "python@3.12",
+    "node": "node",
+    "ruby": "ruby",
+    "perl": "perl",
+    "go": "go",
+    "rustc": "rust",
+    "cargo": "rust",
+    # Build & dev tools
+    "cmake": "cmake",
+    "make": "make",
+    "pkg-config": "pkg-config",
+    "autoconf": "autoconf",
+    "automake": "automake",
+    # Network tools
+    "wget": "wget",
+    "curl": "curl",
+    "httpie": "httpie",
+    "nmap": "nmap",
+    "netcat": "netcat",
+    "nc": "netcat",
+    # System tools
+    "watch": "watch",
+    "htop": "htop",
+    "pstree": "pstree",
+    "lsof": "lsof",
+    "strace": "strace",
+    # Shell tools
+    "bash": "bash",
+    "zsh": "zsh",
+    "fish": "fish",
+    "tmux": "tmux",
+    "screen": "screen",
+    # Compression
+    "pigz": "pigz",
+    "pbzip2": "pbzip2",
+    "xz": "xz",
+    "zstd": "zstd",
+    # Misc
+    "timeout": "coreutils",
+    "gtimeout": "coreutils",
+    "bat": "bat",
+    "exa": "exa",
+    "eza": "eza",
+    "entr": "entr",
+    "parallel": "parallel",
+    "pv": "pv",
+    "rename": "rename",
+    "shellcheck": "shellcheck",
+    "shfmt": "shfmt",
+    "dos2unix": "dos2unix",
+    "icdiff": "icdiff",
+    "difftastic": "difftastic",
+    "socat": "socat",
+    "coreutils": "coreutils",
+    "gnu-sed": "gnu-sed",
+    "gawk": "gawk",
+    "findutils": "findutils",
+    "gnu-tar": "gnu-tar",
+    "gnu-time": "gnu-time",
+    "gnu-which": "gnu-which",
+    "gnu-indent": "gnu-indent",
+    "gnu-getopt": "gnu-getopt",
+}
+
+# --- BSD vs GNU incompatibility patterns ---
+# Each entry: (error_regex, tool_name, formula, g_prefix, description)
+
+WRONG_VERSION_PATTERNS = [
+    # sed
+    (
+        r"sed: 1:.*: invalid command code",
+        "sed", "gnu-sed", "gsed",
+        "BSD sed doesn't support GNU sed syntax"
+    ),
+    (
+        r"sed: 1:.*: extra characters at the end of .* command",
+        "sed", "gnu-sed", "gsed",
+        "BSD sed doesn't support GNU sed syntax"
+    ),
+    (
+        r"sed: -[iI]: .*: No such file or directory",
+        "sed", "gnu-sed", "gsed",
+        "BSD sed -i requires an extension argument"
+    ),
+    # grep
+    (
+        r"grep: invalid option -- P",
+        "grep", "grep", "ggrep",
+        "BSD grep doesn't support -P (Perl regex)"
+    ),
+    (
+        r"grep: invalid option -- 'P'",
+        "grep", "grep", "ggrep",
+        "BSD grep doesn't support -P (Perl regex)"
+    ),
+    # find
+    (
+        r"find: -printf: unknown primary",
+        "find", "findutils", "gfind",
+        "BSD find doesn't support -printf"
+    ),
+    (
+        r"find: -regextype: unknown primary",
+        "find", "findutils", "gfind",
+        "BSD find doesn't support -regextype"
+    ),
+    # xargs
+    (
+        r"xargs: illegal option -- d",
+        "xargs", "findutils", "gxargs",
+        "BSD xargs doesn't support -d (delimiter)"
+    ),
+    (
+        r"xargs: illegal option -- P",
+        "xargs", "findutils", "gxargs",
+        "BSD xargs doesn't support -P (parallel)"
+    ),
+    # date
+    (
+        r"date: illegal option -- d",
+        "date", "coreutils", "gdate",
+        "BSD date doesn't support -d (parse date string)"
+    ),
+    (
+        r"date: illegal option -- -",
+        "date", "coreutils", "gdate",
+        "BSD date doesn't support GNU long options"
+    ),
+    # readlink
+    (
+        r"readlink: illegal option -- f",
+        "readlink", "coreutils", "greadlink",
+        "BSD readlink doesn't support -f (canonicalize)"
+    ),
+    # stat
+    (
+        r"stat: illegal option -- -",
+        "stat", "coreutils", "gstat",
+        "BSD stat uses different syntax than GNU stat"
+    ),
+    (
+        r"stat: unrecognized option",
+        "stat", "coreutils", "gstat",
+        "BSD stat uses different syntax than GNU stat"
+    ),
+    # awk
+    (
+        r"awk: .*function .* is not defined",
+        "awk", "gawk", "gawk",
+        "BSD awk lacks some GNU awk functions"
+    ),
+    (
+        r"awk: .*: unknown option",
+        "awk", "gawk", "gawk",
+        "BSD awk doesn't support some GNU awk options"
+    ),
+    # tar
+    (
+        r"tar: Option --\w+ is not supported",
+        "tar", "gnu-tar", "gtar",
+        "BSD tar doesn't support some GNU tar options"
+    ),
+    # sort
+    (
+        r"sort: invalid option -- V",
+        "sort", "coreutils", "gsort",
+        "BSD sort doesn't support -V (version sort)"
+    ),
+    # head/tail
+    (
+        r"head: illegal line count -- -",
+        "head", "coreutils", "ghead",
+        "BSD head uses different syntax for negative counts"
+    ),
+    (
+        r"tail: illegal offset -- \+",
+        "tail", "coreutils", "gtail",
+        "BSD tail uses different syntax"
+    ),
+]
+
+# Compile regexes once
+COMPILED_WRONG_VERSION = [
+    (re.compile(pattern, re.IGNORECASE), tool, formula, gprefix, desc)
+    for pattern, tool, formula, gprefix, desc in WRONG_VERSION_PATTERNS
+]
+
+# "command not found" patterns
+# Note: we intentionally omit "No such file or directory" — it fires on file paths, not missing commands
+# Two distinct error formats:
+#   bash/sh: "<shell>: <name>: command not found"  → name is between the colons
+#   zsh:     "zsh: command not found: <name>"       → name is after the second colon
+# The negative lookahead (?!:) on pattern 1 stops it from greedily capturing the
+# shell name on a zsh-style line (which would otherwise yield "zsh" as the missing tool).
+MISSING_CMD_PATTERNS = [
+    re.compile(r"(?:bash: |sh: )?(\S+): command not found(?!:)"),
+    re.compile(r"command not found: (\S+)"),
+]
+
+
+def load_ignored_tools() -> set[str]:
+    """Load the persistent ignore list from ~/.claude/tool-misses-ignored.json."""
+    if not IGNORE_FILE.exists():
+        return set()
+    try:
+        with open(IGNORE_FILE) as f:
+            data = json.load(f)
+        return set(data.get("ignored", []))
+    except (json.JSONDecodeError, OSError):
+        return set()
+
+
+def find_session_files(days: int = DEFAULT_DAYS) -> list[Path]:
+    """Find JSONL session files modified within the last N days."""
+    if not SESSIONS_DIR.exists():
+        return []
+
+    cutoff = time.time() - (days * 86400)
+    files = []
+
+    for jsonl_file in SESSIONS_DIR.rglob("*.jsonl"):
+        try:
+            if jsonl_file.stat().st_mtime >= cutoff:
+                files.append(jsonl_file)
+        except OSError:
+            continue
+
+    return sorted(files, key=lambda f: f.stat().st_mtime, reverse=True)
+
+
+def extract_bash_pairs(session_file: Path) -> list[dict]:
+    """
+    Extract Bash tool_use + tool_result pairs from a JSONL session file.
+
+    JSONL format:
+    - Assistant messages (type="assistant") contain tool_use blocks in message.content[]
+    - Tool results come in user messages (type="user") as tool_result blocks in message.content[]
+      with a tool_use_id linking back to the original tool_use
+
+    Returns list of dicts with keys: command, output, tool_use_id, file
+    """
+    pairs = []
+    tool_uses = {}  # tool_use_id -> command
+
+    try:
+        with open(session_file, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                record_type = record.get("type", "")
+                message = record.get("message", {})
+                if not isinstance(message, dict):
+                    continue
+                content_list = message.get("content", [])
+                if not isinstance(content_list, list):
+                    continue
+
+                for block in content_list:
+                    if not isinstance(block, dict):
+                        continue
+
+                    # Collect Bash tool_use from assistant messages
+                    if (
+                        record_type == "assistant"
+                        and block.get("type") == "tool_use"
+                        and block.get("name") == "Bash"
+                    ):
+                        tool_id = block.get("id", "")
+                        command = block.get("input", {}).get("command", "")
+                        if tool_id and command:
+                            tool_uses[tool_id] = command
+
+                    # Collect tool_result from user messages
+                    elif (
+                        record_type == "user"
+                        and block.get("type") == "tool_result"
+                    ):
+                        tool_id = block.get("tool_use_id", "")
+                        if tool_id not in tool_uses:
+                            continue
+
+                        content = block.get("content", "")
+                        if isinstance(content, list):
+                            text_parts = []
+                            for sub in content:
+                                if isinstance(sub, dict) and sub.get("type") == "text":
+                                    text_parts.append(sub.get("text", ""))
+                                elif isinstance(sub, str):
+                                    text_parts.append(sub)
+                            content = "\n".join(text_parts)
+                        elif not isinstance(content, str):
+                            content = str(content)
+
+                        pairs.append({
+                            "command": tool_uses[tool_id],
+                            "output": content,
+                            "tool_use_id": tool_id,
+                            "file": str(session_file),
+                        })
+                        del tool_uses[tool_id]
+
+    except (OSError, PermissionError) as e:
+        print(f"Warning: Could not read {session_file}: {e}", file=sys.stderr)
+
+    return pairs
+
+
+def is_false_positive_missing(cmd: str) -> bool:
+    """Check if a 'command not found' match is a false positive."""
+    # File paths
+    if cmd.startswith("/") or cmd.startswith("./") or cmd.startswith("../"):
+        return True
+    # Sandbox-blocked builtins that Claude shouldn't try to install
+    if cmd.lower() in SANDBOX_BUILTINS:
+        return True
+    # Commands that aren't installable via Homebrew or are expected-missing on macOS
+    if cmd.lower() in IGNORE_COMMANDS:
+        return True
+    # Very short or obviously not a command
+    if len(cmd) <= 1 or " " in cmd:
+        return True
+    # Contains path separators (it's a path, not a command)
+    if "/" in cmd:
+        return True
+    # Starts with a flag
+    if cmd.startswith("-"):
+        return True
+    # Starts with a dot (hidden files, .nvmrc, etc.)
+    if cmd.startswith("."):
+        return True
+    # Contains backslash-escaped characters (from embedded JSON in output)
+    if "\\" in cmd:
+        return True
+    # Contains quotes or commas (from parsing artifacts)
+    if any(ch in cmd for ch in ('"', "'", ",", ";", "(", ")", "{", "}", "[", "]")):
+        return True
+    # Contains colons (e.g., "hackathon_init:7" — shell function errors)
+    if ":" in cmd:
+        return True
+    # ALL_CAPS placeholder words (e.g., PATTERN, COMMAND, TOOL from embedded text)
+    if cmd.isupper() and len(cmd) > 2:
+        return True
+    # Must look like a valid command name: letters, numbers, hyphens, underscores
+    if not re.match(r'^[a-zA-Z_][a-zA-Z0-9._-]*$', cmd):
+        return True
+    return False
+
+
+def detect_missing_tools(pairs: list[dict]) -> dict:
+    """Detect missing tool errors from Bash tool_use/tool_result pairs."""
+    missing = defaultdict(lambda: {"count": 0, "examples": [], "formula": None})
+
+    for pair in pairs:
+        output = pair["output"]
+        for pattern in MISSING_CMD_PATTERNS:
+            for match in pattern.finditer(output):
+                cmd = match.group(1).strip()
+                if is_false_positive_missing(cmd):
+                    continue
+
+                missing[cmd]["count"] += 1
+                if len(missing[cmd]["examples"]) < 3:
+                    missing[cmd]["examples"].append({
+                        "command": pair["command"][:200],
+                        "error": match.group(0)[:200],
+                        "file": pair["file"],
+                    })
+                if cmd in TOOL_TO_FORMULA:
+                    missing[cmd]["formula"] = TOOL_TO_FORMULA[cmd]
+
+    return dict(missing)
+
+
+def detect_wrong_version(pairs: list[dict]) -> dict:
+    """Detect BSD/GNU incompatibility errors from Bash tool_use/tool_result pairs."""
+    wrong = defaultdict(lambda: {
+        "count": 0, "examples": [], "formula": None,
+        "g_prefix": None, "description": None,
+    })
+
+    for pair in pairs:
+        output = pair["output"]
+        for compiled_re, tool, formula, gprefix, desc in COMPILED_WRONG_VERSION:
+            if compiled_re.search(output):
+                wrong[tool]["count"] += 1
+                wrong[tool]["formula"] = formula
+                wrong[tool]["g_prefix"] = gprefix
+                wrong[tool]["description"] = desc
+                if len(wrong[tool]["examples"]) < 3:
+                    wrong[tool]["examples"].append({
+                        "command": pair["command"][:200],
+                        "error_match": compiled_re.pattern,
+                        "file": pair["file"],
+                    })
+
+    return dict(wrong)
+
+
+def main():
+    days = DEFAULT_DAYS
+    if len(sys.argv) > 1:
+        try:
+            days = int(sys.argv[1])
+        except ValueError:
+            print(f"Usage: {sys.argv[0]} [days]", file=sys.stderr)
+            sys.exit(1)
+
+    session_files = find_session_files(days)
+
+    if not session_files:
+        result = {
+            "missing_tools": {},
+            "wrong_version_tools": {},
+            "scan_summary": {
+                "files_scanned": 0,
+                "pairs_analyzed": 0,
+                "days_scanned": days,
+                "error": "No session files found in ~/.claude/projects/",
+            },
+        }
+        json.dump(result, sys.stdout, indent=2)
+        return
+
+    all_pairs = []
+    for sf in session_files:
+        all_pairs.extend(extract_bash_pairs(sf))
+
+    missing = detect_missing_tools(all_pairs)
+    wrong_version = detect_wrong_version(all_pairs)
+
+    # Filter out user-dismissed tools
+    ignored = load_ignored_tools()
+    ignored_found = {k: missing.pop(k) for k in list(missing) if k in ignored}
+    ignored_found.update({k: wrong_version.pop(k) for k in list(wrong_version) if k in ignored})
+
+    result = {
+        "missing_tools": missing,
+        "wrong_version_tools": wrong_version,
+        "ignored_tools": list(ignored_found.keys()),
+        "ignore_file": str(IGNORE_FILE),
+        "scan_summary": {
+            "files_scanned": len(session_files),
+            "pairs_analyzed": len(all_pairs),
+            "days_scanned": days,
+            "total_missing": len(missing),
+            "total_wrong_version": len(wrong_version),
+            "total_ignored": len(ignored_found),
+        },
+    }
+
+    json.dump(result, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/claude-code-tools/skills/tool-misses/scripts/tests/test_detect_tool_misses.py
+++ b/plugins/claude-code-tools/skills/tool-misses/scripts/tests/test_detect_tool_misses.py
@@ -1,0 +1,62 @@
+"""Unit tests for scripts/detect-tool-misses.py.
+
+Run with: uv run --with pytest pytest plugins/developer-tools/skills/tool-misses/scripts/tests/ -x -q
+"""
+
+import importlib.util
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent.parent.resolve() / "detect-tool-misses.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("detect_tool_misses", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+detector = _load()
+
+
+def _pair(output: str, command: str = "mytool --help") -> dict:
+    return {
+        "command": command,
+        "output": output,
+        "tool_use_id": "abc",
+        "file": "/fake.jsonl",
+    }
+
+
+class TestMissingCommandExtraction:
+    def test_zsh_suffix_format_does_not_capture_shell_name(self):
+        # zsh's actual error format puts the missing command AFTER the colon:
+        #   "zsh: command not found: mytool"
+        # A naive regex anchored on "<word>: command not found" greedily captures
+        # "zsh" itself. This is the regression we are guarding against.
+        result = detector.detect_missing_tools(
+            [_pair("zsh: command not found: mytool")]
+        )
+        assert "zsh" not in result
+        assert "mytool" in result
+
+    def test_bash_prefix_format_captures_target_command(self):
+        # bash format: "<shell>: <name>: command not found" — name is mid-string.
+        result = detector.detect_missing_tools(
+            [_pair("bash: mytool: command not found")]
+        )
+        assert "bash" not in result
+        assert "mytool" in result
+
+    def test_sh_prefix_format_captures_target_command(self):
+        # sh format matches bash format. Common in bundle exec / non-login shells.
+        result = detector.detect_missing_tools(
+            [_pair("sh: mytool: command not found")]
+        )
+        assert "sh" not in result
+        assert "mytool" in result
+
+    def test_bare_format_captures_target_command(self):
+        # No shell prefix at all — direct error message.
+        result = detector.detect_missing_tools([_pair("mytool: command not found")])
+        assert "mytool" in result

--- a/plugins/code-review-tools/.claude-plugin/plugin.json
+++ b/plugins/code-review-tools/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "code-review-tools",
+  "version": "0.1.0",
+  "description": "Strict structural and architectural code review that hunts for dramatic simplifications.",
+  "author": {
+    "name": "Fin 2x"
+  },
+  "keywords": [
+    "code-review",
+    "refactoring",
+    "architecture",
+    "quality"
+  ],
+  "license": "MIT"
+}

--- a/plugins/code-review-tools/CHANGELOG.md
+++ b/plugins/code-review-tools/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to the `code-review-tools` plugin are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-07-09
+
+### Added
+
+- Initial release of the `code-review-tools` plugin.
+- `thermo-nuclear-code-review` skill — an extremely strict structural and architectural review of a diff, branch, or file set, hunting for "code judo" moves that dramatically simplify the implementation rather than correctness bugs or style nits.

--- a/plugins/code-review-tools/LICENSE
+++ b/plugins/code-review-tools/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Intercom
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/code-review-tools/README.md
+++ b/plugins/code-review-tools/README.md
@@ -1,0 +1,20 @@
+# code-review-tools
+
+Strict structural and architectural code review that hunts for dramatic simplifications.
+
+Part of the [`fin-2x`](../../README.md) marketplace.
+
+## Install
+
+```
+/plugin marketplace add intercom/2x-skills
+/plugin install code-review-tools@fin-2x
+```
+
+## Skills
+
+- **[thermo-nuclear-code-review](./skills/thermo-nuclear-code-review/)** — An extremely strict structural and architectural review of a diff, branch, or file set. It hunts for "code judo" moves — changes that dramatically simplify the implementation — rather than correctness bugs or style nits. Applies a numbered set of standards (dead code, wrong abstraction layer, reinvented primitives, over-configurable code, …) with severity levels and a high approval bar. Pair it with a separate correctness-focused review; this one is about structure.
+
+## License
+
+MIT

--- a/plugins/code-review-tools/skills/thermo-nuclear-code-review/SKILL.md
+++ b/plugins/code-review-tools/skills/thermo-nuclear-code-review/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: thermo-nuclear-code-review
+description: >
+  Run an extremely strict structural and architectural quality review on a diff, branch,
+  or file set, hunting for "code judo" moves that dramatically simplify the implementation
+  — not correctness bugs or style nits.
+metadata:
+  user-invocable: true
+  argument-hint: "[PR URL, branch, or file paths]"
+  keywords: [thermonuclear, code judo, maintainability audit, harsh review, deep code review]
+allowed-tools: Bash, Read, Glob, Grep
+---
+
+# Thermo-Nuclear Code Quality Review
+
+An unusually strict review focused on structural quality, architectural health, abstraction cleanliness, and codebase maintainability. This is not a correctness review — it asks whether the code is making the codebase *better* or *worse*.
+
+The guiding principle is **code judo**: actively search for restructurings that preserve behavior while making the implementation dramatically simpler, smaller, more direct, and more elegant. Do not stop at "this could be a bit cleaner." Look for moves where whole branches, helpers, modes, conditionals, or layers disappear entirely. Prefer the solution that feels inevitable in hindsight.
+
+## Scope — What This Review IS and IS NOT
+
+| This review covers | This review does NOT cover |
+|---|---|
+| Structural quality and architectural health | Correctness bugs (use a dedicated correctness-focused review) |
+| Abstraction quality and decomposition | Style nits and formatting |
+| Complexity growth and spaghetti detection | Test coverage gaps |
+| Layer violations and architectural drift | Security vulnerabilities |
+| File size and modularity | Performance micro-optimizations |
+| Type boundary and contract cleanliness | Linting violations |
+
+If a correctness review or repo-specific rule enforcement is needed, run that separately. This skill is the architectural conscience.
+
+## Review Context
+
+- **Pin the fixed point first**: Establish what the diff is measured against before reading any code. Use whatever the user supplies — a PR URL, branch, commit SHA, tag, `main`, or `HEAD~5`. If none is given, ask. Then capture the diff once with a three-dot (merge-base) comparison: `git diff <fixed-point>...HEAD`, and the commit list with `git log <fixed-point>..HEAD --oneline`. Before analyzing, confirm the ref resolves (`git rev-parse <fixed-point>`) and the diff is non-empty — a bad ref or empty diff should fail here, not surface as a confusing empty review.
+- **Full-file reads required**: For every file with >10 lines changed, read the entire file, not just diff hunks. Structural review depends on surrounding patterns, file size before the change, and consistency with existing conventions.
+- **Pre-change file size matters**: For files already >800 lines, note the pre-change line count — the 1000-line threshold (Standard 1) is evaluated against the post-change total.
+- **Large diffs**: For diffs >200 changed lines, save to a temp file for reference during analysis.
+- **Code smell baseline**: Apply `references/code-smells.md` alongside the standards — an always-on set of Fowler structural smells (Feature Envy, Data Clumps, Primitive Obsession, Shotgun Surgery, etc.) that catches structural problems the numbered Standards don't name explicitly.
+- **Skip what tooling enforces**: RuboCop, ESLint, Prettier, and type-checkers already block formatting, naming-convention, and lint issues. Do not spend findings on what CI catches — the review's value is the structural judgement no linter can make.
+- **Concrete suggestions**: For each finding, identify the specific standard or smell violated, locate the exact file and line range, and draft a concrete code judo move or restructuring — not a vague observation.
+
+---
+
+## Non-Negotiable Standards
+
+### 0. Be ambitious about structural simplification
+
+Do not stop at "this could be a bit cleaner." Look for opportunities to reframe the change so that whole branches, helpers, modes, conditionals, or layers disappear entirely. Assume there is often a code judo move available — a reorganization that uses the existing architecture more effectively and makes the change dramatically simpler. If you see a path to delete complexity rather than rearrange it, push hard for that path.
+
+### 1. Do not let a PR push a file past 1000 lines without a very strong reason
+
+Treat crossing 1000 lines as a structural smell. Prefer extracting helpers, subcomponents, modules, or local abstractions instead of letting a file sprawl. If the diff crosses that threshold, explicitly call it out. Only waive this if the file is clearly organized and the growth is structurally justified — not just "I added more methods here because this is where the other ones are."
+
+### 2. Do not allow random spaghetti growth
+
+Be highly suspicious of new ad-hoc conditionals, scattered special cases, or one-off branches inserted into unrelated flows. If a change adds if-statements in unrelated code paths, treat that as a design problem, not a stylistic nit. Prefer pushing the logic into a dedicated abstraction, helper, state machine, policy object, or separate module instead of tangling an existing path. Call out changes that make the surrounding code harder to reason about, even if they technically work.
+
+### 3. Bias toward cleaning the design, not just accepting working code
+
+If behavior can stay the same while the structure becomes meaningfully cleaner, push for the cleaner version. Do not rubber-stamp "it works" implementations that leave the codebase messier. Strongly prefer simplifications that remove moving pieces altogether over refactors that merely spread the same complexity around.
+
+### 4. Prefer direct, boring, maintainable code over hacky or magical code
+
+Treat brittle, ad-hoc, or "magic" behavior as a code-quality problem. Be skeptical of generic mechanisms that hide simple data-shape assumptions. Flag thin abstractions, identity wrappers, or pass-through helpers that add indirection without buying clarity.
+
+### 5. Push hard on type and boundary cleanliness
+
+Question unnecessary optionality, loosely-typed interfaces, excessive use of `Hash` params in Ruby, `any`/`unknown` in TypeScript, or cast-heavy code when a clearer type boundary could exist. Prefer explicit typed models or shared contracts over loosely-shaped ad-hoc objects. If a branch relies on silent fallback to paper over an unclear invariant, ask whether the boundary should be made explicit.
+
+### 6. Keep logic in the canonical layer
+
+Most non-trivial codebases have clear architectural layers. Feature logic must not leak into shared paths, and implementation details must not leak through APIs. Prefer existing canonical utilities over bespoke one-offs. Push code toward the right module instead of normalizing architectural drift.
+
+### 7. Feature flags must not create permanent branching debt
+
+A feature flag is a temporary deployment mechanism, not a long-term branching strategy. Flag usage that:
+- Adds conditionals in 3 or more locations (the flag is structuring too much logic)
+- Has no clear cleanup path (no linked issue, no expiry, no `# TODO: remove after...`)
+- Branches deeply inside existing methods rather than wrapping at a higher level
+- Creates nested conditionals (`if flag_a && flag_b`)
+
+### 8. Treat unnecessary sequential orchestration and non-atomic updates as design smells
+
+If independent work is serialized for no good reason, ask whether the flow should run in parallel. If related updates can leave state half-applied, push for a more atomic structure. Do not over-index on micro-optimizations, but flag avoidable orchestration complexity that makes the implementation more brittle.
+
+---
+
+## Common Structural Patterns by Stack
+
+The patterns below are common architectural conventions worth checking regardless of which specific standards or repo-local guides apply. Adapt them to whatever stack the codebase under review actually uses.
+
+**Layered backends (e.g. a Rails or similar monolith):**
+- Controllers should be thin — orchestration belongs in commands, domain logic in services
+- Callbacks (`after_save`, `before_create`) that grow beyond simple defaults are a structural smell — prefer explicit service calls
+- Concerns/mixins that accumulate unrelated methods are God-object anti-patterns — each concern should have a single cohesive purpose
+- N+1 queries introduced by new associations or loops are a structural problem (the query boundary is in the wrong place), not just a performance nit
+
+**Frontend (e.g. React, Ember, or similar component frameworks):**
+- Components past 300 lines of template/JSX should be decomposed
+- Shared modules (e.g. `packages/`, `lib/`) must not accumulate feature-specific logic
+- Mixing older and newer framework idioms within the same file is architectural regression
+
+**Workers/Queues:**
+- New workers must be idempotent — the same message processed twice should produce the same result
+- Workers that mix orchestration with business logic should be split
+- DLQ-unaware workers (no error handling strategy) are a structural gap
+
+---
+
+## Structural Code Smell Baseline
+
+Beyond the numbered Standards, carry an always-on baseline of Fowler's structural "Bad Smells in Code" — the full catalogue with *what it is → how to fix* lives in `references/code-smells.md`. It is the structural floor every diff is measured against, even when the touched files document no standards of their own. It is **not** a new axis (this skill stays single-axis and structural); it widens recall for smells the Standards don't name explicitly: Mysterious Name, Feature Envy, Data Clumps, Primitive Obsession, Repeated Switches, Shotgun Surgery, Divergent Change, Message Chains, Refused Bequest.
+
+Two binding rules keep the baseline honest — **the repo overrides the baseline**, and **every smell is a judgement call, never a hard violation**. `references/code-smells.md` is the single source of truth for both rules and how they bind; apply them from there.
+
+## Escalation Triggers
+
+Beyond the standards above, escalate aggressively when you see patterns that compound over time:
+
+- A complicated implementation where a code judo reframing could delete whole categories of complexity
+- Refactors that move code around but fail to reduce the concepts a reader must hold
+- Copy-pasted logic instead of extracted helpers, or bespoke helpers duplicating a canonical utility
+- "Temporary" branching likely to become permanent debt
+- Callbacks growing beyond simple defaults into orchestration logic
+- At scale: chatty service calls, unbounded queries, synchronous work that should be async
+
+---
+
+## Preferred Remedies
+
+When identifying a structural problem, prefer suggestions like:
+
+- **Delete a whole layer** of indirection rather than polishing it
+- **Reframe the state model** so conditionals disappear instead of getting centralized
+- **Change the ownership boundary** so the feature becomes a natural extension of an existing abstraction
+- **Turn special-case logic** into a simpler default flow with fewer exceptions
+- **Extract a helper or pure function** from an overloaded method
+- **Split a large file** into smaller focused modules
+- **Move feature-specific logic** behind a dedicated abstraction
+- **Replace condition chains** with a typed model, enum, or explicit dispatcher
+- **Separate orchestration from business logic** (commands orchestrate, services contain logic)
+- **Collapse duplicate branches** into a single clearer flow
+- **Delete wrappers** that do not meaningfully clarify the API
+- **Reuse the existing canonical helper** instead of introducing a near-duplicate
+- **Extract a concern** only if it has a single cohesive purpose (not a junk drawer)
+- **Move the logic** to the layer that already owns the concept
+- **Make the worker idempotent** by checking state before mutating it
+
+Do not be satisfied with "maybe rename this" feedback when the real issue is structural. Do not be satisfied with a merely cleaner version of the same messy idea if there is a plausible path to a much simpler idea.
+
+---
+
+## Review Tone
+
+Be direct, serious, and demanding about quality. Do not be rude, but do not soften major maintainability issues into mild suggestions. If the code is making the codebase messier, say so clearly. If the implementation missed an opportunity for a dramatic simplification, say that clearly too.
+
+Good phrases:
+- "this pushes the file past 1k lines — can we decompose before adding more?"
+- "this adds another special-case branch into an already busy flow — can we move this behind its own abstraction?"
+- "this works, but it makes the surrounding code more tangled — let's keep the behavior and restructure"
+- "this feels like feature logic leaking into a shared path — can we isolate it?"
+- "this abstraction isn't earning its keep — can we just use the direct flow?"
+- "there's a code judo move here — if we restructure X, these three branches disappear entirely"
+- "this concern is becoming a junk drawer — it mixes unrelated responsibilities"
+- "this controller is doing domain logic that belongs in a service/command"
+- "this callback chain is growing into orchestration — extract to an explicit service call"
+- "this worker isn't idempotent — what happens if the same message is processed twice?"
+
+---
+
+## Output Format
+
+Present findings in priority order.
+
+### Severity Levels
+
+1. **BLOCKER** — Structural regression that should not merge. Clear architectural violation, unjustified file-size explosion, or missed code judo move that would dramatically simplify the change.
+2. **MAJOR** — Significant structural concern that will create maintenance burden. Spaghetti growth, layer violations, permanent branching debt.
+3. **SUGGESTION** — Structural improvement opportunity. The code works and is not actively harmful, but there is a cleaner path.
+
+### Format per finding
+
+```
+### [BLOCKER/MAJOR/SUGGESTION] — <Short title>
+**File:** `path/to/file.rb:L42-L67`
+**Rule:** <Which standard this violates>
+
+<2-3 sentences: what is wrong and why it matters structurally>
+
+**Code judo move:** <Specific restructuring that would eliminate the problem, if applicable>
+```
+
+### Verdict
+
+End every review with exactly one of:
+
+**APPROVE** — No structural regressions. The codebase is as healthy or healthier after this change.
+
+**RETHINK** — Blocker(s) found. The implementation needs structural rework before merge. Summarize what needs to change.
+
+**REFINE** — No blockers, but major issue(s) worth addressing. Summarize the improvements.
+
+---
+
+## Approval Bar
+
+Do not approve merely because behavior seems correct. The bar is: **no violation of Standards 0–8 above** that the author cannot clearly justify. In particular, treat these as presumptive blockers:
+
+- A plausible code judo move exists that would delete significant incidental complexity
+- The PR pushes a file past 1000 lines
+- The PR scatters feature checks across shared code instead of isolating them
+- The PR duplicates an existing helper or puts logic in the wrong layer
+- The PR adds a worker without idempotency guarantees
+</content>

--- a/plugins/code-review-tools/skills/thermo-nuclear-code-review/references/code-smells.md
+++ b/plugins/code-review-tools/skills/thermo-nuclear-code-review/references/code-smells.md
@@ -1,0 +1,36 @@
+# Structural Code Smell Baseline (Fowler)
+
+An always-on baseline of structural "Bad Smells in Code" (Martin Fowler, _Refactoring_, ch. 3), curated for the thermo-nuclear review. This baseline applies even when a file or repo documents no standards of its own — it is the structural floor every diff is measured against, alongside the Non-Negotiable Standards.
+
+## Two binding rules
+
+These two rules keep the baseline safe and prevent it from manufacturing noise:
+
+1. **The repo overrides the baseline.** A documented pattern in your team's style guide, an existing convention in the surrounding code, or an explicit team standard always wins. Where the codebase deliberately endorses something the baseline would flag (e.g. a canonical `case`/`when` dispatcher that the architecture standardizes on), suppress the smell — do not flag it.
+2. **Every smell is a judgement call, never a hard violation.** Name the smell as a labelled heuristic ("possible Feature Envy here"), quote the hunk, and explain the structural cost. Default smells to **MAJOR** or **SUGGESTION**. Escalate to **BLOCKER** only when a smell compounds a Non-Negotiable Standard — e.g. Duplicated Code that re-implements a canonical helper is also a Standard 6 (canonical layer) violation; Speculative Generality that adds a whole layer of indirection is also a Standard 4 violation.
+
+**Skip anything tooling already enforces.** RuboCop, ESLint, Prettier, and type-checkers catch formatting, naming-convention, and lint issues. Do not spend findings on what CI already blocks — the review's value is the structural judgement no linter can make.
+
+## The smells
+
+Each smell reads *what it is* → *how to fix*. Match each against the diff (and, per the Review Context, against the full files the diff touches).
+
+- **Mysterious Name** — a method, variable, class, or type whose name doesn't reveal what it does or holds. → Rename it. If no honest name comes easily, the design underneath is murky — that's the real finding.
+- **Duplicated Code** — the same logic shape appears in more than one hunk or file in the change. → Extract the shared shape and call it from both. If a canonical helper already exists, reuse it (Standard 6).
+- **Feature Envy** — a method that reaches into another object's data more than its own (chains of `other.x`, `other.y`, `other.z`). → Move the method onto the data it envies, or extract the envious part.
+- **Data Clumps** — the same few fields or parameters keep travelling together (a type wanting to be born). → Bundle them into one value object / struct / typed model and pass that instead.
+- **Primitive Obsession** — a primitive, string, or hash standing in for a domain concept that deserves its own type (Standard 5: type/boundary cleanliness). → Give the concept its own small type rather than threading raw primitives through signatures.
+- **Repeated Switches** — the same `case`/`when` or `if`-cascade on the same type recurs across the change. → Replace with polymorphism, a typed dispatcher, or one map both sites share (Standard 4: replace condition chains). _Suppress if the repo standardizes on an explicit dispatcher — rule 1._
+- **Shotgun Surgery** — one logical change forces scattered edits across many unrelated files in the diff. → Gather what changes together into one module so the next change touches one place (relates to Standard 2: spaghetti growth).
+- **Divergent Change** — one file or module is edited for several unrelated reasons in the same diff. → Split so each module changes for one reason.
+- **Speculative Generality** — abstraction, parameters, hooks, or config added for needs the change doesn't actually have. → Delete it; inline back until a real need shows up (Standard 4: thin abstractions / identity wrappers).
+- **Message Chains** — long `a.b().c().d()` navigation the caller shouldn't depend on. → Hide the walk behind one method on the first object (law of Demeter).
+- **Middle Man** — a class or method that mostly just delegates onward without adding anything. → Cut it and call the real target directly (Standard 4: delete wrappers that don't clarify the API).
+- **Refused Bequest** — a subclass or implementer that ignores or overrides most of what it inherits. → Drop the inheritance and use composition instead.
+
+## How this fits the review
+
+- These smells are the **structural floor**, not a new axis. They feed the same finding format and the same severity ladder (BLOCKER / MAJOR / SUGGESTION) as the Non-Negotiable Standards.
+- When a smell points at a code judo move (whole branches, helpers, or layers disappearing), prefer that framing over a mechanical "extract method" suggestion — Standard 0 still governs.
+- Several smells overlap with the Standards by design (Duplicated Code ↔ Std 2/6, Speculative Generality / Middle Man ↔ Std 4, Primitive Obsession ↔ Std 5, Repeated Switches ↔ Std 4). The catalogue's job is to widen recall for the smells the Standards don't name explicitly — Mysterious Name, Feature Envy, Data Clumps, Shotgun Surgery, Divergent Change, Message Chains, Refused Bequest.
+</content>

--- a/plugins/test-tools/.claude-plugin/plugin.json
+++ b/plugins/test-tools/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-tools",
+  "version": "0.1.0",
+  "description": "Investigate and fix flaky tests across frameworks and CI systems.",
+  "author": {
+    "name": "Fin 2x"
+  },
+  "keywords": [
+    "flaky-tests",
+    "testing",
+    "ci",
+    "rspec",
+    "reliability"
+  ],
+  "license": "MIT"
+}

--- a/plugins/test-tools/CHANGELOG.md
+++ b/plugins/test-tools/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to the `test-tools` plugin are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-07-09
+
+### Added
+
+- Initial release of the `test-tools` plugin.
+- `fix-flaky-tests` skill — investigates and fixes flaky or intermittently-failing tests across frameworks (RSpec, Jest, pytest, Go test, …) and CI systems (Buildkite, CircleCI, GitHub Actions, …), with progressive discovery, a framework-agnostic classification model, and CI-as-the-only-verification discipline.
+- A `UserPromptSubmit` hook that auto-loads the skill on flaky-test phrasing the description alone would miss (advisory questions, disputed issue closures).

--- a/plugins/test-tools/LICENSE
+++ b/plugins/test-tools/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Intercom
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/test-tools/README.md
+++ b/plugins/test-tools/README.md
@@ -1,0 +1,24 @@
+# test-tools
+
+Investigate and fix flaky tests across frameworks and CI systems.
+
+Part of the [`fin-2x`](../../README.md) marketplace.
+
+## Install
+
+```
+/plugin marketplace add intercom/2x-skills
+/plugin install test-tools@fin-2x
+```
+
+## Skills
+
+- **[fix-flaky-tests](./skills/fix-flaky-tests/)** — Investigates and fixes flaky or intermittently-failing tests. Detects the test framework (RSpec, Jest, pytest, Go test, …) and CI provider (Buildkite, CircleCI, GitHub Actions, …), then applies a framework-agnostic classification model (global-state poisoning, test ordering, timing/race, resource exhaustion, external-service flake, …). Enforces hard rules: never skip a test as a "fix", never propose a fix without the actual CI error, and treat a green CI build as the only authoritative verification. Extensible via per-framework, per-CI, and per-app reference files — add your own; none ship by default beyond RSpec + Buildkite.
+
+## Hooks
+
+`test-tools` installs a `UserPromptSubmit` hook that auto-loads the skill for flaky-test phrasing the skill description alone would miss — advisory questions ("should I run it more locally?", "did my fix make it worse?") and disputes of a wrongly-closed flaky-test issue. Non-blocking; it only injects a context reminder.
+
+## License
+
+MIT

--- a/plugins/test-tools/hooks/flaky-spec-skill-auto-inject.sh
+++ b/plugins/test-tools/hooks/flaky-spec-skill-auto-inject.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# UserPromptSubmit hook that auto-injects the fix-flaky-tests skill instruction
+# when user asks about flaky tests, CI-only failures, test reproduction, or browser-crash noise.
+#
+# The skill description triggers reliably for investigation prompts ("investigate this
+# flaky test") but misses advisory questions ("should I run more locally?", "did my fix
+# make things worse?", "how do I verify this CI-only flake?"). This hook catches those
+# edge cases by keyword-matching the user's prompt.
+
+# Read hook event data from stdin
+hook_data=$(cat)
+
+# Extract user message from the JSON
+user_message=$(echo "$hook_data" | jq -r '.prompt // empty' 2>/dev/null)
+
+# Trigger paths (case-insensitive), evaluated in PRIORITY ORDER. The order matters: a
+# dispute of a wrongly-closed issue can be phrased as "review #123 ... wrongly closed <url>",
+# so the dispute path must win BEFORE the PR-review exclusion, or the exclusion would
+# swallow a flow the skill advertises.
+#
+# Path A — disputing the closure/diagnosis of a tracker issue. The skill description triggers
+#   on "reopen / dispute a wrongly-closed flaky-test issue", but such prompts usually carry
+#   NO flaky keyword — the flaky-ness lives in the issue's title/label, not the prompt text
+#   (e.g. "Address this issue, I think it was wrongly closed <url>"). Require BOTH dispute
+#   language AND an explicit issue URL to stay specific; the skill opens the issue and bows
+#   out if it turns out not to be a flaky-test issue.
+dispute_re='(wrongly|incorrectly|mis-?) ?(closed|identified|diagnos)|re-?investigate|reopen|wrong root cause|dispute(d)?.{0,25}(closure|diagnosis|root cause)'
+issue_url_re='https?://[^[:space:]]+/issues/[0-9]+'
+#
+# Path B exclusion — a request to *review a pull request* is a code-review task, not a
+#   flaky-test investigation, even when it mentions a flaky spec ("review this PR that
+#   fixes a flaky spec ..."). Matches only explicit PR / code-review phrasing —
+#   deliberately NOT a bare "review #123", which can be an issue dispute handled by Path A.
+review_re='\breview (this |the )?(pull request|pr)\b|\bcode review\b'
+#
+# Path C — flaky-test SIGNAL phrasing. Framework-agnostic — matches "flaky test", "fails in
+#   CI", "passes on retry", "xit/skipped test" etc., not bare framework names (matching
+#   "jest" or "pytest" alone false-fires on ordinary "set up jest" / "run pytest" prompts).
+flaky_signal_re='\b(flaky|intermittent(ly)?|fail(s|ing)? in ci|passes locally|passes on retry|ci.only|flake|browser crash|xit|skipped (spec|test))\b'
+
+if echo "$user_message" | grep -qiE "$dispute_re" \
+   && echo "$user_message" | grep -qiE "$issue_url_re"; then
+    : # Path A — dispute of a closed issue: fire
+elif echo "$user_message" | grep -qiE "$review_re"; then
+    exit 0  # Path B — PR-review request: not an investigation
+elif echo "$user_message" | grep -qiE "$flaky_signal_re"; then
+    : # Path C — flaky signal: fire
+else
+    exit 0  # No match - no additional context
+fi
+
+# Create auto-inject marker for telemetry
+session_id=$(echo "$hook_data" | jq -r '.session_id // empty' 2>/dev/null)
+if [[ -n "$session_id" ]]; then
+    marker_dir="/tmp/auto-injected-skills/${session_id}"
+    mkdir -p "$marker_dir"
+    touch "${marker_dir}/fix-flaky-tests"
+fi
+
+# Inject instruction to use fix-flaky-tests skill
+cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": "FLAKY TESTS: Before investigating or advising on a flaky test, load the fix-flaky-tests skill. It runs progressive discovery of the test framework, CI provider, and app profile, then applies the matching classification table, CI-only reproduction guidance, browser-crash noise interpretation, and infrastructure fast-exit logic. Use: Skill(skill: \"test-tools:fix-flaky-tests\")"
+  }
+}
+EOF

--- a/plugins/test-tools/hooks/hooks.json
+++ b/plugins/test-tools/hooks/hooks.json
@@ -1,0 +1,11 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          { "type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/flaky-spec-skill-auto-inject.sh\"" }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/test-tools/skills/fix-flaky-tests/SKILL.md
+++ b/plugins/test-tools/skills/fix-flaky-tests/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: fix-flaky-tests
+description: Investigate and fix flaky or intermittently-failing tests in any framework and CI system — detects the framework, CI provider, and app profile, then applies the matching classification and fix patterns. Triggers on a flaky-test issue or CI URL, a test that "passes on retry" or "fails in CI but passes locally", a bot that skipped a test, or a request to reopen or dispute the closure or diagnosis of a flaky-test issue (for that case open the issue first; its title or label confirms scope even when the prompt has no flaky-test keywords).
+allowed-tools: Bash Read Grep Glob Edit Write Skill
+---
+
+# Fix Flaky Tests
+
+Reference guide for investigating and fixing flaky tests across frameworks (RSpec, Jest,
+pytest, Go test, …), CI systems (Buildkite, CircleCI, GitHub Actions, …), and apps. The
+methodology is universal; framework idioms, CI log-fetch procedures, and app-specific flake
+catalogues are loaded on demand via **progressive discovery**. Compose the workflow to the
+situation rather than following rigid steps.
+
+<HARD-RULES>
+- NEVER skip a test (xit, skip, pending, `t.Skip`, `.skip`, etc.) as a fix
+- NEVER fabricate a root cause — if you can't identify it, say so
+- NEVER propose a fix without the actual CI error message (exception + backtrace from the CI logs, or pasted verbatim by the user)
+- NEVER proceed with code-only analysis if the CI error cannot be established. Stop and ask the user for it. There is no "reduced confidence" mode.
+- NEVER assume infrastructure flakiness without build-wide evidence
+- Only fix if you can identify the root cause with HIGH confidence
+- NEVER claim a fix is complete until CI is green — a "fix" that fails CI is not a fix. Monitor the PR build, investigate failures, and iterate until it passes.
+- Verification of a proposed fix must come from a green CI build, never from local runs. Local runs cannot replicate CI's parallelism, shared caches, or cross-test ordering, so a local pass means almost nothing.
+- Local reproduction during **investigation** (observing state while the bug happens, confirming the mechanism) is a different activity — allowed and encouraged when the test environment is available. When no environment is available (headless), the investigation is limited to CI logs + code reading.
+</HARD-RULES>
+
+## Required Input
+
+One of:
+- A bug-tracker issue link about a flaky test
+- A test file path
+- A CI build/job URL with a failing run
+- An advisory question about a flaky test (reproduction strategy, verification, noise interpretation)
+- A request to address, reopen, or dispute a *closed* flaky-test issue ("this was mis-identified / wrongly closed")
+
+**Disputed or already-closed issues — re-derive, don't trust the close.** Treat any
+existing investigation or closing comment as a hypothesis, not a finding — re-establish the
+root cause from the actual CI logs (the HARD GATE below applies regardless of what the
+comment claims). Closing comments are frequently plausible-but-wrong: they cite a mechanism
+that doesn't match the real backtrace, or apply the infrastructure fast-exit ("a shared
+dependency was briefly down → no code fix") to a build where only **one** test failed. A
+single-example failure is the opposite of build-wide infra evidence — it usually means that
+one test is uniquely fragile: e.g. a strict assertion on a process-global sink (an error
+reporter, a metrics client) with no pass-through fallback, tripped by a benign *handled*
+report emitted by unrelated setup during the same example. That is a fixable code-side bug
+owned by the test's source team, not an infra ticket. If you reopen, correct the routing to
+that owning team.
+
+## Discover the Environment (do this first)
+
+Before classifying anything, detect the stack so the right knowledge loads. Run the
+detection in **`references/discovery.md`** — it covers three tiers:
+
+1. **Test framework** (from `Gemfile`/`package.json`/`pyproject.toml`/`go.mod` + test dirs)
+   → load `references/frameworks/<framework>.md`. Only `rspec.md` ships fully fleshed;
+   others fall back to `references/classification-generic.md` + `frameworks/_template.md`.
+2. **CI provider** (from `.buildkite/`/`.circleci/`/`.github/workflows/`) → load
+   `references/ci/<provider>.md` for how to fetch logs. Only `buildkite.md` ships fully
+   fleshed; others use `ci/_template.md`, but the HARD GATE below still applies.
+3. **App profile** (from `git remote get-url origin`) → load `references/profiles/<app>.md`
+   if one matches (e.g. `your-org/your-app` → `profiles/your-app.md`). No app profiles ship
+   by default — add your own by following the shape in `references/discovery.md`. If none
+   matches, use the generic + framework tiers only and do not invent app-specific
+   classifications.
+
+State the detected stack in one line, then proceed. If a tier is unknown, say so and note
+the degraded mode.
+
+## Fast Exits (cheap — no CI logs needed)
+
+Check these BEFORE fetching CI logs or doing deep investigation. They rely only on git and
+PR history, so they resolve an issue even when CI logs have expired or the CI MCP is
+unavailable — which is exactly when an already-fixed or already-PR'd issue would otherwise
+get stuck on the HARD GATE below. Most flaky-test issues are settled here without a full
+investigation.
+
+### Already Fixed
+
+Many flaky-test issues already have a fix merged but the issue was never closed. Check for a
+merged fix before investigating:
+
+- Test file commits since the issue date: `git log --oneline --since="<issue_date>" -- <test_file>`
+- Source file commits over the same window: `git log --oneline --since="<issue_date>" -- <source_file>`
+- Merged PRs referencing the test: `gh pr list --search "<test_file_name>" --state merged --limit 5`
+
+If any surface a relevant merged fix, **STOP** and report it. Also close any stale bot-skip
+PRs the real fix superseded.
+
+**Partial-fix guard:** if a fix is merged but new flaky issues were filed *after* the fix
+date for the same file (possibly a different test within it), the fix was partial — continue
+to historical recurrence.
+
+### Existing Open PR
+
+`gh pr list --search "<test_file_name>" --state open` — if one exists, review it rather than
+starting over.
+
+### Broken, Not Flaky
+
+`git log --oneline -10 -- <test_file>` and `-- <source_file>`. Signals of broken (not
+flaky): ALL tests in the file fail, deterministically, every run, any seed/order; failures
+started after a specific commit. Fix: update the test's setup for the new dependency.
+
+### Historical Recurrence (Systemic Signal)
+
+`gh search issues "<test_file_name>" --limit 30 --json number,state,createdAt | jq 'length'`.
+**If 3+ issues exist for the same file:** read ALL prior fix PRs, find the common
+vulnerability, and fix it systemically. Fixing only the reported test regenerates the issue
+within weeks. (App profiles record known serial offenders.)
+
+### Bot Skips
+
+Automated tools "fix" flaky tests by skipping them — never a valid fix, it only hides the
+failure. Detect the skip with the framework file's grep pattern and check authorship with
+`git log --oneline -1 -- <test_file>`. Action depends on whether the root cause is fixed:
+
+| Bot skipped | Root cause fixed | Action |
+|-------------|------------------|--------|
+| Yes | Yes | Revert the skip, open a PR restoring coverage |
+| Yes | No | Revert the skip AND fix the root cause in the same PR |
+
+## CI Log Access (HARD GATE)
+
+If the fast exits above did not resolve the issue, you are doing a real investigation — and
+the actual CI error message is essential. Code-only analysis produces plausible but wrong
+hypotheses — in one real case, code analysis concluded "case not created (timeout)" when
+the actual error was "wrong case found (suffix collision)."
+
+Fetch the failing job's logs using the CI provider file for the detected provider (e.g.
+`references/ci/buildkite.md`). Extract: exception class + message + backtrace, total
+failed-test count, and which unique files are affected.
+
+**If logs are unavailable** — MCP not connected, API down, logs expired, retrieval returns
+nothing useful — ask the user to paste the error verbatim. A user-pasted error is
+equivalent to a tool-fetched one for this gate. Stop and wait rather than guessing.
+**Code-only analysis is never an acceptable substitute.** Do not retry failing log calls
+more than twice in a session.
+
+## Classify the Failure
+
+Start with the framework-agnostic categories in **`references/classification-generic.md`**
+(broken-not-flaky, global state poisoning, test-ordering, timing/race, suffix collision,
+resource exhaustion, external-service flake, thread-boundary state, …). Then consult the
+**framework file** for how the category manifests in that framework's idioms, and the **app
+profile** for product-specific instances (specific services, error classes, infra).
+
+**Infrastructure fast-exit:** a build-wide pattern (many unrelated tests across several
+files failing in one run) almost always means infrastructure, not a test bug — close the
+issue, no code fix. The app profile defines the exact threshold and common infra exceptions.
+
+**Quick heuristics:** passes on retry in the same build → test-side (state/ordering/timing);
+all tests in a file fail every run → broken by a code change, not flaky.
+
+## Investigate Root Cause
+
+Reproduction vs verification are different activities. **Reproduction** runs the test to
+observe state while the bug happens — a way to close a confidence gap during investigation.
+**Verification** ("has my fix worked?") always belongs on CI (see below).
+
+Most CI flakes do NOT reproduce locally. Limit to 2 local attempts per hypothesis; if it
+passes twice, the flake is CI-only and further local runs add no signal. The framework file
+gives the replay command; **`references/ci-only-flakes.md`** explains which categories
+reproduce locally vs not, browser/driver noise, and measurement-driven verification.
+
+For **state poisoning** (common), the poisoner is usually a sibling test that mutates global
+state and doesn't restore it; confirm by running it before the victim at the same seed. For
+**timing**, look for wall-clock assertions without a frozen clock and too-short async waits.
+For **resource issues**, prefer the infra fast-exit over a test-side fix.
+
+## Propose and Implement Fix
+
+**Only with a HIGH-confidence root cause.** Fix at the source, not the symptom — a per-test
+workaround masks the systemic bug and gets copied by the next engineer.
+
+**Scope before writing:** once the root-cause pattern is known, grep the suite for it. If
+more than one test is vulnerable, the fix belongs in source or a shared helper, not copied
+into each test. Lead the PR with the systemic fix; any unskip is secondary.
+
+For test-level fixes when a systemic fix isn't possible: fix the poisoner, harden the victim
+with explicit setup as defense-in-depth, and follow the framework's mocking conventions.
+
+If you cannot identify the root cause, STOP. Report what you found and tried. No speculative
+changes.
+
+**When creating a PR**, use your PR-creation workflow (e.g. `gh pr create`) rather than
+pushing straight to the default branch. Route review to the team that owns the **source**
+file — the app profile names the mechanism if one exists (e.g. a constant listing owning
+teams). Enable auto-merge so it lands on green.
+
+## Verify the Fix
+
+**CI is the only authoritative signal.** A fix that passes 40 local runs but fails in CI is
+not a fix. The fix is complete only when the PR build is green; keep iterating on the branch
+until it passes. A local pass means almost nothing — never treat it as verification.
+
+For **CI-only flakes**, use measurement-driven verification: compare CI failure rates
+between a baseline branch (unchanged) and an experiment branch (fix) over N builds each,
+excluding infra noise. See `references/ci-only-flakes.md`. Note the provider may cancel
+superseded branch builds, so baseline and experiment need separate branches.
+
+When CI fails on an **unrelated** test, consult **`references/handling-unrelated-ci-failures.md`** —
+do not modify the unrelated failing test in your fix PR.
+
+## Sweep for Siblings
+
+**Same-file first.** Most recurring flakes share a vulnerability with sibling tests in the
+same file — a partial fix is the leading cause of recurring issues. Fix every hit of the
+unsafe pattern inside the reported file before the PR goes out. A suite-wide sweep is
+secondary — useful for blast radius and deciding whether to lift the fix into a shared
+helper.
+
+## Update Guidance (Novel Findings)
+
+If the root cause is a new framework-agnostic category, add it to
+`references/classification-generic.md`. If it's framework-specific, update the framework
+file; if product-specific, your app profile. To support a new framework or CI provider, copy
+the matching `_template.md` and register its signal in `references/discovery.md`. After
+every fix, ask: "Could this skill have caught this earlier or more completely?" If so, open
+a PR to this skill's repo.
+
+## Additional Resources
+
+### Reference Files
+
+- **`references/discovery.md`** — detect framework / CI / app, and what to load
+- **`references/classification-generic.md`** — framework-agnostic flake categories
+- **`references/frameworks/rspec.md`** — RSpec idioms, repro commands (fully fleshed); `_template.md` for new frameworks
+- **`references/ci/buildkite.md`** — Buildkite log-fetch (fully fleshed); `_template.md` for new providers
+- **`references/ci-only-flakes.md`** — CI-only reproduction, noise filtering, measurement-driven verification
+- **`references/handling-unrelated-ci-failures.md`** — diagnosing CI failures unrelated to your fix PR
+
+App profiles (`references/profiles/<app>.md`) are an extensibility point for your own
+product-specific flake catalogue and workflow conventions — none ship by default; add your
+own by following the shape described in `references/discovery.md`.
+
+### Worked Examples
+
+Following the Reported → Validated → Classified → Root cause → Fix → Sweep → Guidance format
+(both are synthetic RSpec cases):
+
+- **`examples/cross-app-guardrails-poisoning.md`** — global state poisoning via module-level instance variables
+- **`examples/thread-local-cache-signup-spec.md`** — thread-local cache in Capybara feature specs

--- a/plugins/test-tools/skills/fix-flaky-tests/examples/cross-app-guardrails-poisoning.md
+++ b/plugins/test-tools/skills/fix-flaky-tests/examples/cross-app-guardrails-poisoning.md
@@ -1,0 +1,17 @@
+# RateLimitGuard Poisoning (synthetic example)
+
+**Reported**: `spec/services/rate_limit_guard_spec.rb` failing intermittently in CI.
+
+**Validated**: CI log search on the failing job showed the exception + backtrace, matching a few recent default-branch builds.
+
+**Reproduced**: Failed locally with `bundle exec rspec --seed 34567 --order random spec/services/order_export_spec.rb spec/services/rate_limit_guard_spec.rb` — the poisoner-then-victim ordering at that seed reproduces the failure deterministically.
+
+**Classified**: Global state poisoning — seed-dependent, passes in isolation.
+
+**Root cause**: `RateLimitGuard` (`app/services/rate_limit_guard.rb`) tracks its on/off state in a module-level instance variable (`@enabled`), toggled via `RateLimitGuard.disable!` / `RateLimitGuard.enable!`. Two unrelated specs, `order_export_spec.rb` and `team_permissions_spec.rb`, had `around` hooks that called `RateLimitGuard.disable!` and then, in an `ensure` block meant to restore the default, mistakenly called `disable!` again instead of `enable!` — leaving `@enabled = false` for every test that ran afterward in the same process.
+
+**Fix**: Changed the `ensure` blocks in both specs to call `RateLimitGuard.enable!` (the initializer default). Hardened the victim spec with an explicit `RateLimitGuard.enable!` in a `before` block as defense-in-depth.
+
+**Sweep**: Grepped the suite for the same pattern (`grep -rn 'RateLimitGuard.disable!' spec/`) and found `webhook_delivery_spec.rb`'s `clean_up` helper had the identical bug — fixed that too.
+
+**Guidance updated**: Added a "Module-Level Instance Variables" row to `references/classification-generic.md`'s global-state-poisoning entry, and noted the `around`/`ensure` restore-to-wrong-value gotcha as a pattern to grep for on future poisoning investigations.

--- a/plugins/test-tools/skills/fix-flaky-tests/examples/thread-local-cache-signup-spec.md
+++ b/plugins/test-tools/skills/fix-flaky-tests/examples/thread-local-cache-signup-spec.md
@@ -1,0 +1,15 @@
+# Thread-Local Cache in Checkout Feature Spec (synthetic example)
+
+**Reported**: `spec/features/checkout_spec.rb` "Guest completes checkout without creating an account" failing with `expected "/orders/confirmation" to match /\/account\/orders\/.+\/receipt/`.
+
+**Validated**: CI log search on the failing job showed 1 failure — `RSpec::Expectations::ExpectationNotMetError` at the redirect assertion. Passed after retry.
+
+**Classified**: Thread-local cache in feature specs — non-deterministic redirect caused by a feature-flag TTL cache in the Rails server thread.
+
+**Root cause**: The shared helper `create_guest_checkout_mocks(saved_card: false)` sets `fake_customer.email_verified = false`. After `sign_in(customer)` in `OrdersController`, `Customer#requires_email_verification?` (`app/models/customer.rb`) returns `true` because: (1) the flag `"email-verification-required"` is not globally enabled in the test database, (2) `created_at >= EMAIL_VERIFICATION_START_DATE`, and (3) `!email_verified?`. The existing stub, `allow_any_instance_of(Order).to receive(:skip_verification?)`, was on the **wrong method** — it stubs `Order#skip_verification?`, but the redirect logic actually calls `Customer#requires_email_verification?`. The flakiness mechanism: `FeatureFlag.globally_enabled?` caches its result in `Thread.current[:global_features]` with a TTL. Capybara runs the Rails server in a separate thread from the spec thread, so `FeatureFlag.clear_thread_cache` — called in the spec's own `after` hook — only clears the **spec thread's** cache. Stale cached data from a prior spec can make the flag appear enabled on the **server thread**, suppressing the verification redirect on some runs and not others.
+
+**Fix**: Added `allow_any_instance_of(Customer).to receive(:requires_email_verification?).and_return(false)` to the `before` block in `checkout_feature_helpers.rb`. `allow_any_instance_of` is required (not a stub on a specific instance) because the Rails server thread loads its own `Customer` instance from the database — a specific-instance stub set up on the spec thread would never cross the thread boundary.
+
+**Sweep**: `create_guest_checkout_mocks(via_social_login: false)` in the same helper has the identical `email_verified = false` pattern — the fix in the shared helper protects every checkout feature spec that uses it, not just the reported one.
+
+**Guidance updated**: Added a "Thread-local cache in feature specs" row to the framework file's manifestation table, describing the `Thread.current`-backed cache + Capybara-separate-thread mechanism as a category to check for whenever a feature spec's redirect assertion flakes.

--- a/plugins/test-tools/skills/fix-flaky-tests/references/ci-only-flakes.md
+++ b/plugins/test-tools/skills/fix-flaky-tests/references/ci-only-flakes.md
@@ -1,0 +1,71 @@
+# CI-Only Flakes: Why Local Reproduction Fails
+
+Many flakes never reproduce locally because they depend on conditions that only exist in
+CI: **concurrency** (many parallel workers sharing backing services), **load** (slow
+responses, timeouts, contention), and **environment** (real datastores, different configs,
+clean process state). A test that passes 100/100 times locally can fail 1/10 in CI because
+these introduce non-determinism a single dev machine doesn't have.
+
+This file is framework- and CI-agnostic. For the concrete scale and shared-service facts of
+a specific app (e.g. a large test suite's parallel worker count and real
+memcached/DynamoDB/Redis/ES backing services), see that app's profile, e.g.
+`references/profiles/your-app.md` — add your own if useful.
+
+## Categories that rarely reproduce locally
+
+| Category | Why local passes | What to do instead |
+|----------|------------------|--------------------|
+| Suffix / identifier collision | Low-resolution identifiers are unique on one machine; collide across many parallel workers | Fix: append high-entropy uniqueness to the identifier |
+| Thread-boundary cache staleness | Caches only go stale under parallel access patterns | Fix: stub at the boundary the other thread crosses |
+| Cache TTL expiration | Cache ops are fast locally, slow under CI load | Fix: lengthen TTL for the test, or use an in-memory fake |
+| Lock / resource contention | No contention with one process | Fix: stub the lock/resource when not under test |
+| Background-thread DB race | Transaction-rollback races only matter with concurrent threads | Fix: stub the method that spawns the background work |
+
+For these, local runs give zero signal. Limit local attempts to 2 per hypothesis; if it
+passes twice, switch to measurement-driven verification.
+
+## Measurement-driven verification
+
+When local runs can't reproduce the flake, verify a fix by comparing CI failure rates
+across two branches:
+
+1. **Baseline branch** (no fix): push the unchanged test, trigger N CI builds, record the
+   pass rate — excluding infrastructure noise (e.g. browser crashes).
+2. **Experiment branch** (with fix): push the proposed fix to a *separate* branch, trigger
+   N CI builds, record the pass rate — same noise exclusion.
+3. **Compare:** a meaningful improvement needs enough builds to clear the noise floor. For
+   a ~10% failure rate, N=10 is a starting point; N=20+ gives clearer signal. If the two
+   rates are statistically indistinguishable, the fix probably isn't addressing the cause —
+   go back to classification.
+
+This is the only rigorous verification for flakes that cannot be reproduced locally.
+
+**Separate branches are required** when the CI provider cancels superseded builds on a
+branch (Buildkite's `cancel_running_branch_builds`, and similar on other providers). You
+cannot A/B two variants on one branch — pushing the experiment kills the baseline build.
+See the CI provider file (e.g. `references/ci/buildkite.md`) for the provider's specifics.
+
+## Filtering infrastructure noise from measurements
+
+Some "failures" are infrastructure, not the test: browser/driver crashes
+(`SessionNotCreatedError`), datastore-unavailable errors, OOM kills. Exclude these before
+computing pass rates. If *every* failure in a batch is infra noise, the measurement is
+unreliable and the test may not be flaky at all. See the framework file for how its
+browser/driver failures look.
+
+## When local verification IS useful
+
+For **test-ordering** or **state-poisoning** flakes, local reproduction with the correct
+seed and test list often works — see the framework file for the exact replay command. If it
+reproduces, iterate locally (limit 2 attempts). Otherwise treat it as CI-only.
+
+## Decision table: local vs CI verification
+
+| Situation | Local useful? | Strategy |
+|-----------|--------------|----------|
+| State poisoning / ordering with known seed | Yes | Replay seed + test list, iterate locally |
+| Suffix / identifier collision | No | Fix the identifier, push PR, monitor CI |
+| Thread-boundary / cache staleness | No | Fix the stub, push PR, monitor CI |
+| Browser/driver crash noise | No (noise) | Push PR, monitor CI, ignore crashes |
+| Infrastructure (datastore unavailable) | No (no code fix) | Close the issue |
+| Unknown / low confidence | No | Do NOT push a speculative fix — document findings on the issue, gather more CI failure samples, escalate to the owning team |

--- a/plugins/test-tools/skills/fix-flaky-tests/references/ci/_template.md
+++ b/plugins/test-tools/skills/fix-flaky-tests/references/ci/_template.md
@@ -1,0 +1,37 @@
+# CI Provider: <NAME> — TEMPLATE
+
+Copy this file to `references/ci/<provider>.md` to add support for a new CI provider, then
+register its detection signal in `references/discovery.md`. The job of a CI file is to
+answer one question: **how do I get the real error message, seed/order, and failing-test
+list for a specific failing job?** Everything in `SKILL.md`'s HARD GATE depends on it.
+
+## Fetching the error
+
+The exact tools/commands/API for this provider. Examples:
+- CircleCI: `get_build_failure_logs` / `get_job_test_results` MCP tools, or the CircleCI API
+- GitHub Actions: `gh run view <run-id> --log-failed`, `gh run download`, the Checks API
+
+Parse out: exception/error message + stack trace, total failed-test count, distinct files
+affected, and the random seed/order if the framework randomizes.
+
+## Provider-specific gotchas
+
+Anything that makes log retrieval non-obvious — log retention windows, retried/rerun jobs
+attaching logs to a new run, matrix jobs splitting output, artifact-only test reports, etc.
+
+## If logs are unavailable
+
+The HARD GATE still applies. If logs can't be retrieved (auth, retention, API down), ask
+the user to paste the exception and backtrace verbatim. A user-pasted error is equivalent
+for the gate. Code-only analysis is never a substitute.
+
+## A/B verification constraints
+
+Whether this provider cancels superseded builds on a branch (which forces baseline and
+experiment onto separate branches), concurrency limits, and how to trigger N runs for
+measurement-driven verification (`references/ci-only-flakes.md`).
+
+## Listing default-branch builds
+
+How to list recent runs on the default branch to establish whether a failure pre-exists a
+PR (`references/handling-unrelated-ci-failures.md`).

--- a/plugins/test-tools/skills/fix-flaky-tests/references/ci/buildkite.md
+++ b/plugins/test-tools/skills/fix-flaky-tests/references/ci/buildkite.md
@@ -1,0 +1,55 @@
+# CI Provider: Buildkite
+
+How to fetch the failing job's logs and the error message — the input the HARD GATE in
+`SKILL.md` requires before any classification. Buildkite is the log source for repos with a
+`.buildkite/` directory.
+
+## Fetching the error
+
+Use your Buildkite tooling of choice (the Buildkite API, a Buildkite MCP server, or the
+`buildkite` CLI) to read the failing job's logs directly:
+
+```
+- find the build and the failing job (build/job lookup)
+- fetch the job's log output and search it for the error message, seed, and spec/test list
+```
+
+Parse out: exception class + message + backtrace, total failed-test count, and which
+unique files are affected (the count of distinct files drives the infra fast-exit in
+`SKILL.md`).
+
+## Auto-retried jobs (common gotcha)
+
+When a job fails and is auto-retried, Buildkite attaches the logs to the **retry** job (a
+new UUID). The original UUID is still listed when you fetch the build, but searching logs
+on it returns "job not found" because the logs live on the retry. When that happens: fetch
+the build with no job-state filter, find the retry job by name, and use its UUID to fetch
+logs.
+
+## If logs are unavailable
+
+API not connected, timing out, logs expired, or the log search returns nothing useful — ask
+the user to paste the error verbatim:
+
+> I couldn't get the CI error from Buildkite (reason: …). Can you paste the exception and
+> backtrace from the failing job, or check that Buildkite access is configured so I can
+> fetch it?
+
+A user-pasted error is equivalent to a Buildkite-fetched one for the HARD GATE. Do not
+retry failing Buildkite calls more than twice in a session. Code-only analysis is never an
+acceptable substitute.
+
+## `cancel_running_branch_builds` limitation (affects A/B verification)
+
+Buildkite's `cancel_running_branch_builds` setting kills all but the latest build on a
+branch. Consequences for measurement-driven verification (`references/ci-only-flakes.md`):
+
+- A "with fix" and "without fix" build cannot run simultaneously on the **same** branch.
+- Pushing a new commit while a build runs kills the previous build.
+- Comparing two variants **requires separate branches**, each kept untouched while builds run.
+
+## Listing default-branch builds (for unrelated-failure triage)
+
+To establish whether a failure pre-exists your PR, list recent builds on the default
+branch (filtering by that branch name) and check whether the same test is failing there.
+See `references/handling-unrelated-ci-failures.md`.

--- a/plugins/test-tools/skills/fix-flaky-tests/references/classification-generic.md
+++ b/plugins/test-tools/skills/fix-flaky-tests/references/classification-generic.md
@@ -1,0 +1,34 @@
+# Generic Flaky-Test Classification
+
+Framework-agnostic categories. Every flaky test falls into one of these classes regardless
+of language or runner. Use this table first, then consult the matching
+`references/frameworks/<framework>.md` for how the category manifests in that framework's
+idioms, and `references/profiles/<app>.md` for product-specific instances.
+
+| Category | Signals (language-agnostic) | Fix direction |
+|----------|------------------------------|---------------|
+| **Actually broken (not flaky)** | All tests in a file fail. Deterministic on every run, any seed/order. Started after a specific commit. | Find the breaking commit; fix the new dependency or revert. Not a flake. |
+| **Global state poisoning** | Order/seed-dependent. Passes in isolation. A sibling test mutates process-global state (class/module variable, thread-local, singleton, env var, global registry) and doesn't restore it. | Fix the poisoner's cleanup (restore default in teardown/ensure). Harden the victim with explicit setup as defense-in-depth. |
+| **Test-ordering dependency** | Shared database/fixture state leaks between tests; suite-level setup (`before(:all)`, module-scoped fixtures) has side effects. | Isolate per-test setup/teardown. Avoid suite-scoped mutable state. |
+| **Timing / race condition** | Wall-clock or time-window assertions without a frozen clock; async expectations without synchronization; polling with too-short waits. | Freeze/inject time; await the condition explicitly; widen synchronization, not sleeps. |
+| **Shared-singleton collision** | A test double or factory uses a hardcoded key into a process-wide store (in-memory client, cache, registry). Parallel tests overwrite each other's data. | Use a unique key per instance (UUID/random suffix). |
+| **Suffix / identifier collision under parallelism** | Wrong record found. Identifier built from a low-resolution source (second-precision timestamp, small random range) collides across many parallel workers. | Append high-entropy uniqueness (e.g. a random hex suffix). Never rely on second-precision timestamps or tiny random ranges for cross-worker uniqueness. |
+| **Cache TTL expiration** | Test writes to a real cache with a short TTL; under load the entry expires before the code reads it. | Lengthen the TTL for the test context, or use an in-memory fake. |
+| **Resource exhaustion / infrastructure** | OOM kills, connection-pool exhaustion, datastore-cluster pressure. **Build-wide pattern** — many unrelated tests fail in the same run. | Investigate infrastructure, not the test. Do NOT skip. See the infra fast-exit in `SKILL.md`. |
+| **External-service flake** | Network timeouts, third-party API errors in CI; passes locally where the service is mocked or reachable. | Improve mocking/isolation so the test doesn't depend on a live external call. |
+| **Non-deterministic ordering of results** | Positional assertions (`result[0]`) fail because the underlying query/collection has no defined order. | Assert by membership/match, not position; or impose an explicit order. |
+| **Assertion expectation set in setup** | ALL tests in a group fail with "expected to receive X but didn't" — a strict expectation in shared setup masks the real error. | Use a permissive stub for isolation in setup; reserve strict expectations for the test body. |
+| **Thread-boundary state** | A test runs production code in a separate thread/process (browser driver, background worker) that reads state the test set on a different thread; cleanup on the test thread doesn't reach it. | Stub at a boundary that crosses the thread (e.g. instance-level on the model the other thread loads), not the test-thread-local cache. |
+| **Background-thread / async DB race** | Failures in tests that *follow* a test whose code spawns a background thread touching the database; the thread races the test-transaction rollback. | Stub the method that spawns the background work so nothing touches the DB after the test ends. |
+
+## Quick heuristics
+
+- Passes on retry within the same run → test-side issue (state, ordering, timing), not infra-on-its-own.
+- All tests in a file fail every run, any order → broken by a code change, not flaky.
+- Many unrelated files fail in one run → infrastructure; take the fast-exit.
+
+## Adding a category
+
+If a root cause doesn't fit any row, add it here only if it's genuinely
+framework-agnostic. Framework-specific mechanics belong in the framework file;
+product-specific instances belong in the app profile.

--- a/plugins/test-tools/skills/fix-flaky-tests/references/discovery.md
+++ b/plugins/test-tools/skills/fix-flaky-tests/references/discovery.md
@@ -1,0 +1,126 @@
+# Environment Discovery
+
+Flaky-test investigation depends on three things that vary by repository: the **test
+framework**, the **CI provider**, and the **app profile** (product-specific conventions
+and known flake patterns). Detect each one before classifying a failure, then load only
+the matching tier files. This keeps the generic methodology in `SKILL.md` while pulling in
+the right framework idioms, log-fetch procedure, and app-specific flake catalogue.
+
+Run detection once at the start of an investigation. It is cheap (a few `ls`/`grep`/`git`
+calls) and determines which reference files are worth loading.
+
+## 0. Target repository (resolve this first)
+
+Everything below — framework files, CI log-fetch, app profile, and the git/PR-history fast
+exits — must target the **code repo the failing test actually lives in**. That is not
+always the repo you are checked out in (the skill may be invoked from other working
+directories), and — critically — it is **not reliably the repo named in an issue or CI
+URL**:
+
+- **Issue-tracker URLs are often centralized.** Flaky-test issues for many repos may be
+  filed in one shared tracker repo, even for tests that live in a different code repo. The
+  `github.com/<org>/<repo>` in an issue link is the *tracker* repo, which may not be the
+  code repo.
+- **CI URLs name pipelines, not repos.** A Buildkite pipeline slug
+  (`buildkite.com/<org>/<pipeline>`) is not necessarily a repo name.
+
+So do not infer the code repo from a URL's path. Instead, anchor on the **failing test
+file**:
+
+1. Get the failing test's file path — usually named in the issue title/body or the user's
+   prompt; fall back to the CI logs if it isn't. The issue/CI URLs are inputs to *identify
+   the test*, not a source of the repo name.
+2. The target repo is whichever repo contains that file. Check the current checkout first:
+   `git ls-files --error-unmatch <test_file>` (or `ls <test_file>`). If it resolves, the
+   current checkout is the target — confirm with `git remote get-url origin`.
+3. **If the current checkout does not contain the failing test file**, you are in the wrong
+   repo: the git/PR-history fast exits (`git log`, `gh pr list`) and file-based framework
+   detection would silently run against the wrong project. Say so and switch to (or ask the
+   user for) the checkout that contains the test before continuing.
+
+The framework (§1) and CI (§2) signals below are then read from the **target** repo's
+checkout, and the app profile (§3) from the **target** repo's identity (`git remote get-url
+origin` of that checkout) — never from a tracker-issue or pipeline URL.
+
+## 1. Test framework
+
+Detect from files in the repo root (and the test directory layout). First match wins; a
+repo can run more than one, in which case pick the framework that owns the failing file.
+
+| Signal | Framework | Load |
+|--------|-----------|------|
+| `Gemfile` + `.rspec` or `spec/` dir | RSpec (Ruby) | `references/frameworks/rspec.md` |
+| `package.json` with `jest`/`vitest` dep, `*.{test,spec}.{js,jsx,ts,tsx}` | Jest / Vitest (JS/TS) | `references/frameworks/<jest>.md` if present, else `_template.md` |
+| `pytest.ini` / `tox.ini` / `pyproject.toml [tool.pytest.ini_options]` + `tests/` | pytest (Python) | framework file if present, else `_template.md` |
+| `go.mod` + `*_test.go` | `go test` (Go) | framework file if present, else `_template.md` |
+
+Only `frameworks/rspec.md` ships fully fleshed today. For any other framework, fall back to
+`references/classification-generic.md` (the categories are language-agnostic) and treat
+`frameworks/_template.md` as the shape a new framework file should take.
+
+## 2. CI provider
+
+The provider determines **how to fetch the failing job's logs** — the single most important
+input (see the HARD GATE in `SKILL.md`).
+
+**A CI URL in the prompt wins — check it before the repo config.** If the user supplied a
+build/job URL, the provider is whatever that URL points at, regardless of which config
+directories the repo carries:
+
+| URL host / shape | Provider |
+|--------|----------|
+| `buildkite.com/...` | Buildkite |
+| `circleci.com/...` or `app.circleci.com/...` | CircleCI |
+| `github.com/<org>/<repo>/actions/runs/...` | GitHub Actions |
+
+This matters in multi-CI repos: a repo with `.buildkite/` may still be failing on a GitHub
+Actions run linked in the issue. Detecting the provider from config dirs there would load the
+wrong log-fetch procedure and then fail the hard gate (or ask for pasted logs) even though the
+correct logs were fetchable. Always reconcile the provider with the URL the user gave you.
+
+**No URL given — detect from CI config directories:**
+
+| Signal | Provider | Load |
+|--------|----------|------|
+| `.buildkite/` (e.g. `pipeline.yml`) | Buildkite | `references/ci/buildkite.md` |
+| `.circleci/config.yml` | CircleCI | `references/ci/<circleci>.md` if present, else `_template.md` |
+| `.github/workflows/*.yml` running tests | GitHub Actions | `references/ci/<github-actions>.md` if present, else `_template.md` |
+
+If a repo matches more than one signal and no URL disambiguates, ask the user which CI ran the
+failing job rather than guessing.
+
+Only `ci/buildkite.md` ships fully fleshed today. For any other provider, the HARD GATE
+still applies — get the real CI error from that provider's UI/API/logs, or ask the user to
+paste the exception and backtrace. `ci/_template.md` is the shape a new CI file should take.
+
+## 3. App profile
+
+Detect from the **target** repo's identity — `git remote get-url origin` of the checkout
+that contains the failing test file (resolved in §0), never from a tracker-issue or pipeline
+URL. The app profile carries product-specific flake patterns (services, error classes,
+infra) and workflow conventions (PR routing, bot behaviour) that the generic core cannot
+know.
+
+No app profiles ship with this skill by default — the mechanism is an extensibility point,
+not a bundled catalogue:
+
+| Repo | Profile | Load |
+|------|---------|------|
+| `your-org/your-app` | (example) | `references/profiles/your-app.md` |
+| (anything else) | none bundled | skip — use generic + framework tiers only |
+
+When no profile matches, do not invent app-specific classifications. Use
+`classification-generic.md` plus the framework file, enforce the HARD GATE, and say plainly
+which app-specific knowledge is unavailable. Add your own app profile by creating
+`profiles/<your-app>.md` (see the pattern implied by the generic + framework files) and
+registering its repo here.
+
+## Output of discovery
+
+State the detected stack in one line before investigating, e.g.:
+
+> Detected: RSpec / Buildkite / no app profile — loading `frameworks/rspec.md`,
+> `ci/buildkite.md`.
+
+If any tier is unknown, say so and note the degraded mode (generic categories only, HARD
+GATE unchanged).

--- a/plugins/test-tools/skills/fix-flaky-tests/references/frameworks/_template.md
+++ b/plugins/test-tools/skills/fix-flaky-tests/references/frameworks/_template.md
@@ -1,0 +1,47 @@
+# Framework: <NAME> (<LANGUAGE>) — TEMPLATE
+
+Copy this file to `references/frameworks/<framework>.md` to add support for a new test
+framework, then register its detection signal in `references/discovery.md`. Keep
+framework-level mechanics here; product-specific patterns belong in an app profile.
+
+## Detecting an automated skip
+
+How a bot or engineer skips a test in this framework, and how to detect it. Examples:
+- Jest/Vitest: `it.skip`, `describe.skip`, `xit`, `test.todo`
+- pytest: `@pytest.mark.skip`, `@pytest.mark.xfail`, `pytest.skip(...)`
+- Go: `t.Skip(...)`, a `//go:build ignore` guard
+
+```bash
+# grep pattern(s) that find a skip in this framework
+git log --oneline -1 -- <test_file>   # who skipped it, and when
+```
+
+A skip is never a valid fix — revert it alongside the real fix.
+
+## Reproduction commands
+
+The command(s) to replay a specific test with a fixed seed/order and the failing test
+list. Note whether this framework randomizes order (and the flag to pin the seed):
+- Jest: `jest --runInBand --testPathPattern=... --seed=<n>` (with `--seed` support)
+- pytest: `pytest -p no:randomly` / `pytest-randomly --randomly-seed=<n> <nodeids>`
+- Go: `go test -run TestName -count=1 ./pkg/...` (note `-count=1` disables caching)
+
+State the local-vs-CI reproduction caveat for this framework.
+
+## Framework-specific manifestations
+
+How each generic category from `references/classification-generic.md` shows up in this
+framework's idioms, with the fix direction. Fill the rows that actually occur:
+
+| Generic category | <framework> mechanics & fix |
+|------------------|------------------------------|
+| Global state poisoning | (module-level mutable state, shared fixtures, etc.) |
+| Test-ordering dependency | (suite-scoped setup, shared temp state) |
+| Timing / race | (fake timers, async/await, polling) |
+| Assertion expectation in setup | (strict mock in beforeEach/fixture) |
+| Thread/process-boundary state | (workers, subprocesses, browser drivers) |
+
+## Mocking / isolation conventions
+
+The idiomatic way to stub, fake time, and isolate state in this framework. Note any
+host-app rules file the profile should point to.

--- a/plugins/test-tools/skills/fix-flaky-tests/references/frameworks/rspec.md
+++ b/plugins/test-tools/skills/fix-flaky-tests/references/frameworks/rspec.md
@@ -1,0 +1,68 @@
+# Framework: RSpec (Ruby / Rails)
+
+How the generic flake categories (`references/classification-generic.md`) manifest in
+RSpec, plus the RSpec-only mechanics, detection commands, and reproduction commands. This
+file is framework-level — it applies to any RSpec/Rails app. Product-specific patterns
+(particular services, error classes, infra) live in the app profile, e.g.
+`references/profiles/your-app.md` (add your own — none ship by default).
+
+## Detecting an automated skip
+
+The generic "automated skip" fast-exit (see `SKILL.md`) appears in RSpec as `it`→`xit`,
+`describe`→`xdescribe`, `context`→`xcontext`, or a trailing `, skip:` / `pending`:
+
+```bash
+grep -n 'xit\|xdescribe\|xcontext\|, skip:\|pending' <spec_file>
+git log --oneline -1 -- <spec_file>   # who skipped it, and when
+```
+
+A skip is never a valid fix. Revert it as part of the real fix (revert + fix root cause in
+one PR if the root cause isn't yet fixed; revert alone if it is).
+
+## Reproduction commands
+
+State-poisoning and ordering flakes CAN reproduce locally with the right seed and spec
+list (everything else is usually CI-only — see `references/ci-only-flakes.md`):
+
+```bash
+bundle exec rspec --seed <seed> <poisoner_spec> <victim_spec>   # ordering / poisoning
+bundle exec rspec --seed <seed> <spec_list_from_ci>             # replay the CI bin
+```
+
+Limit to 2 attempts per hypothesis. If it passes twice, the flake is CI-only; stop running
+locally and switch to measurement-driven verification.
+
+## RSpec-specific manifestations
+
+| Generic category | RSpec mechanics & fix |
+|------------------|------------------------|
+| **Global state poisoning** | Poisoner mutates a `@@class_var`, module `@ivar`, `Thread.current[:x]`, or a constant, often in an `around`/`after` hook whose `ensure` restores the wrong value. Find mutators: `grep -rn 'disable!\|@@\|Thread.current\[' spec/`. Fix the hook to restore the initializer default; harden the victim with explicit setup in `before`. |
+| **Test-ordering dependency** | `before(:all)` / `before(:context)` side effects and fixtures leak across examples. Move state into `before(:each)`; reset associations in `before`. |
+| **Timing / race** | `Time.now`/`Time.zone.now`/`Time.current.to_i` near an `expect` without `freeze_time`. Freeze the clock or inject time. Note: `freeze_time` can make time-window/refresh races *worse* (it clamps every query) — prefer fixing the source's time handling. |
+| **Assertion expectation in setup** | `expect(...).to receive` in a `before` block makes ALL examples fail with "expected to receive X but didn't", masking the real error. Change `expect` to `allow` for isolation stubs in `before`; keep `expect` in the example body. |
+| **Mutable shared config** | A config/memoized method returns a direct reference to a hash that another example mutates → `KeyError` or unexpected values. Return `.deep_dup`, or stub the config in tests. |
+| **Non-deterministic ordering** | Positional assertions (`response[0]`) on an unordered AR/ES query. Use `match_array` or `find { |e| e["key"] == value }`. |
+| **STI / autoload race** | `config.eager_load = false` in the test env: an association scope built before an STI subclass is loaded returns a subset. Reorder `let!` to load the subclass first; add `association(:name).reset` in `before`. |
+| **Background-thread DB race** | Source uses `Concurrent::Future.execute` / a thread pool; the background thread's DB call races RSpec's transaction rollback (`TRILOGY_CLOSED_CONNECTION`, random failures in the *next* spec). Stub the spawning method: `allow(described_class).to receive(:background_method).and_return(nil)`. |
+| **Thread-boundary state (Capybara `:js`)** | A feature spec drives a real browser; the Rails server runs in a separate thread that loads its own model instances and its own thread-local caches. Clearing a thread-local in the test thread doesn't reach the server thread, so stale cached flags cause non-deterministic redirects. Stub at the model boundary the server thread loads: `allow_any_instance_of(Model).to receive(:flag?).and_return(false)` — `allow_any_instance_of` is correct because the server thread loads a fresh instance from the DB. |
+
+## Capybara / Selenium browser-crash noise
+
+Feature specs run a real browser via Selenium. Under CI load Chrome/Chromium crashes
+intermittently:
+
+```
+Selenium::WebDriver::Error::SessionNotCreatedError: Could not start a new session
+```
+
+These are **infrastructure noise, not spec-logic failures**. When measuring fix efficacy,
+filter browser crashes out before computing pass rates. If every failure in a batch is a
+browser crash, the measurement is unreliable and the spec may not be flaky at all — the
+browser is. Do NOT treat a browser-crash-only failure set as a regression signal.
+
+## RSpec mocking conventions
+
+Fix the poisoner first, harden the victim second. Prefer `allow` over `expect` for setup
+stubs. Route mocks by argument value, never by call-order counters (call order is
+non-deterministic under parallel execution). If the host app ships RSpec mocking rules
+(e.g. a `.claude/rules/rspec.md`), follow them — the app profile names the path.

--- a/plugins/test-tools/skills/fix-flaky-tests/references/handling-unrelated-ci-failures.md
+++ b/plugins/test-tools/skills/fix-flaky-tests/references/handling-unrelated-ci-failures.md
@@ -1,0 +1,30 @@
+# Handling Unrelated CI Failures on Fix PRs
+
+A fix PR may fail CI on a **completely unrelated test** that is broken on the default
+branch. This is common — a broad change (e.g. editing a shared test helper) can widen the
+set of tests that run, raising the chance of hitting a pre-existing breakage. Some apps
+have test-selection systems that normally run a subset; a shared-helper edit can force a
+full run. (For app-specific selection behaviour, see your app profile, e.g.
+`references/profiles/your-app.md`.)
+
+## Establishing that the failure is unrelated
+
+The failure is unrelated when the failing test has no edit-graph or data-graph connection to
+your change, and the same failure appears on recent default-branch builds. Check this by
+reading the failing test, comparing it to your diff, then listing recent default-branch
+builds (via the CI provider file, e.g. `references/ci/buildkite.md`) — if the default branch
+is also failing on the same test, or `git log --oneline --since="1 week ago" -- <failing_test_file>`
+shows churn matching a known fix-in-flight, the breakage pre-exists your PR.
+
+Once established as unrelated, **do not modify the unrelated failing test in your fix PR** —
+that dilutes the review and creates an artificial dependency. Resolve it by moving your
+branch forward or by retrying, based on the state of the default branch:
+
+| Default-branch state for the failing test | Action |
+|--------------------------------------------|--------|
+| Fix already merged | Rebase onto the latest default branch and force-push: `git fetch origin <default> && git rebase origin/<default> && git push --force-with-lease` |
+| Still broken | Retry the build — the broken test may land in a different shard/bin on retry and pass. If it keeps failing, wait for the upstream fix to land, then rebase. |
+
+If the failure turns out to be related to your change after all (the backtrace touches code
+you edited, or the test exercises a path you modified), it is not "unrelated" — treat it
+like any other flaky-test investigation and fix it in your PR.


### PR DESCRIPTION
### Why?

We have a set of internally-developed Claude Code skills that are useful well beyond Intercom. This publishes the five highest-value ones to the public fin-2x marketplace so a general audience can use them, with all Intercom-internal data stripped out.

### How?

Three new plugins, grouped by concern:

- **claude-code-tools** — `permissions-analyzer`, `tool-misses`, `cc-cost-analysis`, plus opt-out nudge hooks
- **test-tools** — `fix-flaky-tests`, plus its auto-inject hook
- **code-review-tools** — `thermo-nuclear-code-review`

Skills were chosen on real fleet adoption (distinct users over 60 days) and on how much survives stripping into something a general audience can use:

| Skill | Distinct users (60d) |
|---|---|
| permissions-analyzer | 187 |
| tool-misses | 65 |
| fix-flaky-tests | 60 |
| thermo-nuclear-code-review | 27 |
| cc-cost-analysis | 5 |

The two already-published skills sit at 132 and 96 distinct users, so the top of this list is well inside the bar already set. Rightsizing and cc-analytics were considered and cut as too infra/telemetry-coupled to be worth much once stripped.

Stripping: removed internal repo names, incident IDs, team names, internal skill cross-references, and internal hostnames; dropped the eval harnesses and Intercom-specific app profiles (matching the two already-published skills); reframed `cc-cost-analysis` around Claude Code's public OpenTelemetry export and removed real spend figures; rewrote the `fix-flaky-tests` worked examples as synthetic RSpec cases.

A full-tree grep for internal markers comes back clean (only the public repo path and the standard MIT copyright remain), all manifests validate, and the `tool-misses` test suite passes.

<sub>Generated with Claude Code</sub>